### PR TITLE
End event

### DIFF
--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -24,7 +24,8 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm run build-web-component && npm pack ./web-component
+          npm run build-web-component
+          npm pack ./web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
           npm publish project-sunbird-sunbird-video-player-web-component-* --access public
       

--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -27,5 +27,5 @@ jobs:
           npm run build-web-component
           npm pack ./web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish project-sunbird-sunbird-video-player-web-component-* --access public
+          npm publish jeraldj-sunbird-video-player-web-component-* --access public
       

--- a/.github/workflows/publish_web_component.yml
+++ b/.github/workflows/publish_web_component.yml
@@ -24,8 +24,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm run build-web-component
-          npm pack ./web-component
+          npm run build-web-component && npm pack ./web-component
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          npm publish jeraldj-sunbird-video-player-web-component-* --access public
+          npm publish project-sunbird-sunbird-video-player-web-component-* --access public
       

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.spec.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.spec.ts
@@ -32,7 +32,7 @@ describe('SunbirdVideoPlayerComponent', () => {
     jasmine.clock().install();
   });
 
-  afterEach(function() {
+  afterEach(function () {
     jasmine.clock().uninstall();
   });
   it('should create SunbirdVideoPlayerComponent', () => {
@@ -57,7 +57,9 @@ describe('SunbirdVideoPlayerComponent', () => {
     const event = {};
     spyOn(component.playerEvent, 'emit').and.callThrough();
     spyOn(component.viewerService, 'raiseHeartBeatEvent').and.callFake(() => 'true');
+    spyOn(component.viewerService, 'raiseEndEvent');
     component.exitContent(event);
+    expect(component.viewerService.raiseEndEvent).toHaveBeenCalled();
     expect(component.playerEvent.emit).toHaveBeenCalledWith({});
     expect(component.viewerService.raiseHeartBeatEvent).toHaveBeenCalledWith('EXIT');
   });

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
@@ -2,7 +2,7 @@ import {
   ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output, OnChanges, SimpleChanges,
   HostListener, ElementRef, ViewChild, AfterViewInit, Renderer2, OnDestroy
 } from '@angular/core';
-import { ErrorService , errorCode , errorMessage, ISideBarEvent } from '@project-sunbird/sunbird-player-sdk-v9';
+import { ErrorService, errorCode, errorMessage, ISideBarEvent } from '@project-sunbird/sunbird-player-sdk-v9';
 
 import { PlayerConfig } from './playerInterfaces';
 import { IAction } from './playerInterfaces';
@@ -74,8 +74,8 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
         let code = errorCode.contentLoadFails,
           message = errorMessage.contentLoadFails;
         if (this.viewerService.isAvailableLocally) {
-            code = errorCode.contentLoadFails;
-            message = errorMessage.contentLoadFails;
+          code = errorCode.contentLoadFails;
+          message = errorMessage.contentLoadFails;
         }
         if (code === errorCode.contentLoadFails) {
           this.showContentError = true;
@@ -102,14 +102,14 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
   ngOnInit() {
     this.isInitialized = true;
     if (this.playerConfig) {
-    if (typeof this.playerConfig === 'string') {
-      try {
-        this.playerConfig = JSON.parse(this.playerConfig);
-      } catch (error) {
-        console.error('Invalid playerConfig: ', error);
+      if (typeof this.playerConfig === 'string') {
+        try {
+          this.playerConfig = JSON.parse(this.playerConfig);
+        } catch (error) {
+          console.error('Invalid playerConfig: ', error);
+        }
       }
     }
-  }
     setInterval(() => {
       if (!this.isPaused) {
         this.showControls = false;
@@ -122,7 +122,7 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
     this.sideMenuConfig = { ...this.sideMenuConfig, ...this.playerConfig.config.sideMenu };
     this.videoPlayerService.initialize(this.playerConfig);
     this.viewerService.initialize(this.playerConfig);
-    window.addEventListener('offline', this.raiseInternetDisconnectionError , true);
+    window.addEventListener('offline', this.raiseInternetDisconnectionError, true);
     this.QumlPlayerConfig.config = this.playerConfig.config;
     this.QumlPlayerConfig.config.sideMenu.enable = false;
     this.QumlPlayerConfig.context = this.playerConfig.context;
@@ -191,7 +191,7 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
         this.QumlPlayerConfig.context.objectRollup = {};
       }
       const levels = Object.keys(this.QumlPlayerConfig.context.objectRollup);
-      this.QumlPlayerConfig.context.objectRollup[`l${levels.length +  1}`] = id;
+      this.QumlPlayerConfig.context.objectRollup[`l${levels.length + 1}`] = id;
     }
   }
 
@@ -208,7 +208,11 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
   }
 
   exitContent(event) {
-    this.viewerService.raiseEndEvent(true);
+    try {
+      this.viewerService.raiseEndEvent(true);
+    } catch (error) {
+      console.error('Error while raising end event: ', error);
+    }
     this.playerEvent.emit(event);
     this.viewerService.raiseHeartBeatEvent('EXIT');
   }
@@ -243,13 +247,13 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
       if (!document.fullscreenElement && this.isFullScreen) {
         if (document.getElementsByClassName('video-js')[0]) {
           document.getElementsByClassName('video-js')[0].requestFullscreen()
-          .catch((err) => console.error(err));
+            .catch((err) => console.error(err));
         }
       }
     }
   }
 
-  questionSetData({response, time, identifier}) {
+  questionSetData({ response, time, identifier }) {
     this.QumlPlayerConfig.metadata = response;
     this.QumlPlayerConfig.metadata['showStartPage'] = 'No';
     this.QumlPlayerConfig.metadata['showEndPage'] = 'No';
@@ -258,7 +262,7 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
     if (document.fullscreenElement) {
       this.isFullScreen = true;
       document.exitFullscreen()
-      .catch((err) => console.error(err));
+        .catch((err) => console.error(err));
     } else {
       this.isFullScreen = false;
     }
@@ -281,6 +285,6 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
     this.unlistenTouchStart();
     this.unlistenMouseMove();
     this.viewerService.isEndEventRaised = false;
-    window.removeEventListener('offline', this.raiseInternetDisconnectionError , true);
+    window.removeEventListener('offline', this.raiseInternetDisconnectionError, true);
   }
 }

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
@@ -208,6 +208,7 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
   }
 
   exitContent(event) {
+    this.viewerService.raiseEndEvent(true);
     this.playerEvent.emit(event);
     this.viewerService.raiseHeartBeatEvent('EXIT');
   }

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@project-sunbird/sunbird-video-player-web-component",
+  "name": "@jeraldj/sunbird-video-player-web-component",
   "version": "2.0.0",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jeraldj/sunbird-video-player-web-component",
-  "version": "2.0.0",
+  "name": "@project-sunbird/sunbird-video-player-web-component",
+  "version": "2.0.1",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {


### PR DESCRIPTION
1. Changes in the Player Repositories (The "Emission" Fix)

a. Synchronous END Event: exitContent and ngOnDestroy ogic in the PDF, ePub, and Video players to explicitly and synchronously call raiseEndEvent()
b. Previously, they depended on logic that could be safely executed in a browser but was too slow/fragile for a mobile "Hardware Back" navigation.