### PR TITLE
Add Dependabot configuration and dependency submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+version: 2
+updates:
+  # Root workspace — Angular workspace config, dev tooling, and shared deps
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      angular:
+        patterns:
+          - "@angular/*"
+          - "@angular-devkit/*"
+          - "@angular-eslint/*"
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+      karma-testing:
+        patterns:
+          - "karma*"
+          - "jasmine*"
+          - "@types/jasmine*"
+          - "@types/jasminewd2"
+      types:
+        patterns:
+          - "@types/*"
+
+  # Library package — the publishable Angular library (projects/sunbird-video-player)
+  - package-ecosystem: "npm"
+    directory: "/projects/sunbird-video-player"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sunbird:
+        patterns:
+          - "@project-sunbird/*"
+
+  # Web component build — standalone ES module distribution
+  - package-ecosystem: "npm"
+    directory: "/web-component"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,67 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-video-player/package.json'
+      - 'projects/sunbird-video-player/package-lock.json'
+      - 'web-component/package.json'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'projects/sunbird-video-player/package.json'
+      - 'projects/sunbird-video-player/package-lock.json'
+      - 'web-component/package.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-npm-root:
+    name: Submit npm (root)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  submit-npm-library:
+    name: Submit npm (projects/sunbird-video-player)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./projects/sunbird-video-player
+
+  submit-npm-web-component:
+    name: Submit npm (web-component)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No lock file in web-component/ — generate one without installing node_modules
+      - run: npm install --package-lock-only
+        working-directory: web-component
+      - uses: advanced-security/npm-dependency-submission-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ./web-component


### PR DESCRIPTION
## Summary                                             

  - Enables Dependabot to automatically open weekly PRs for outdated npm dependencies across all three workspaces (root, `projects/sunbird-video-player`, `web-component`) and keeps  
  GitHub Actions versions current.
  - Adds a `dependency-submission` workflow to populate the GitHub Dependency Graph, which Dependabot uses to detect transitive vulnerabilities.                                      
  - Schedules dependency submission at 03:00 UTC (Monday) so the graph is fresh before Dependabot runs at 03:30.                                                                      
                                                                                                                                                                                      
  ## Changes                                                                                                                                                                          
                                                                                                                                                                                      
  - Add `.github/dependabot.yml` — four Dependabot update blocks: npm root (with groups for Angular, Sunbird, Karma/Jasmine, and `@types/`), npm library, npm web-component, and      
  `github-actions`
  - Add `.github/workflows/dependency-submission.yml` — three parallel jobs that submit the dependency graph for each npm workspace; triggers on push/PR to `master` (when lock files 
  change), weekly schedule, and `workflow_dispatch`                                                                                                                                   
  ## How to Test
                                                                                                                                                                                      
  1. Merge this PR into `master`.                        
  2. Navigate to **Settings → Code security → Dependency graph** on GitHub — all three npm sub-projects should appear as registered manifests within a few minutes.
  3. Navigate to **Insights → Dependency graph** and confirm packages from `package-lock.json`, `projects/sunbird-video-player/package-lock.json`, and the generated
  `web-component/package-lock.json` are listed.                                                                                                                                       
  4. On the following Monday (or trigger **Actions → Dependency Submission → Run workflow** manually), verify the workflow completes successfully.                                    
  5. By 03:30 UTC the next Monday, Dependabot should open its first batch of update PRs labelled `dependencies`.                                                                      
                                                                                                                                                                                      
  ## Checklist                                                                                                                                                                        
                                                                                                                                                                                      
  - [ ] Tests added or updated                                                                                                                                                        
  - [ ] Documentation updated (if public API or behavior changed)
  - [ ] No breaking changes — or breaking changes noted with `!` in title and explained in Summary
  - [ ] Reviewed my own diff before requesting review