### PR TITLE
feat: add word highlight overlay and transcript management in video p…

### DIFF
--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.html
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.html
@@ -1,6 +1,12 @@
-<video #target class="video-js" controls crossorigin="anonymous" (loadeddata)="onLoadMetadata($event)">
-  <track *ngFor="let trans of transcripts" default="{{trans.default}}" kind="captions" src="{{trans.artifactUrl}}" srclang="{{trans.languageCode}}" label="{{trans.language}}" >
-</video>
+<!-- Transcript/caption <track> elements are attached imperatively via
+     player.addRemoteTextTrack() in video-player.component.ts (see
+     attachTranscriptTracks/syncTranscriptTracks) rather than declared here.
+     video.js's removeRemoteTextTrack() - needed to support transcripts
+     updating after initial load - only works on tracks added that way, not
+     on statically-declared HTML <track> elements, so ALL tracks (including
+     the first ones) go through the same imperative path for consistency. -->
+<video #target class="video-js" controls crossorigin="anonymous" (loadeddata)="onLoadMetadata($event)"></video>
+<div #wordHighlightOverlay class="word-highlight-overlay" [class.word-highlight-overlay--hidden]="!showWordHighlightOverlay"><span #wordHighlightLine></span></div>
 <div #controlDiv>
   <div [ngClass]="{'player-for-back-ward-controls': currentPlayerState === 'pause' || showControls }">
     <div class="player-container" *ngIf="currentPlayerState === 'pause' || showControls">

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -250,13 +250,4 @@ div[data-marker-key] {
     border-radius: 0.2em;
     text-align: center;
   }
-
-  // renderWordHighlightLine() injects this span via raw innerHTML rather than
-  // Angular's renderer/template, so it never gets the scoped _ngcontent
-  // attribute emulated encapsulation relies on - ::ng-deep is required here
-  // for the same reason it's needed for .vjs-text-track-display above.
-  ::ng-deep .word-highlight-word--current {
-    color: #fff;
-    font-weight: 700;
-  }
 }

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -201,7 +201,7 @@ div[data-marker-key] {
   margin-left: 0.7% !important;
 }
 
-.vjs-texttrack-settings { // To do because we are disabled this feature and there is enhancement needed based on feture and requirements
+.vjs-texttrack-settings { // To do because we are disabled this feature and there is enhancement needed based on feature and requirements
   display: none;
 }
 

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -251,8 +251,12 @@ div[data-marker-key] {
     text-align: center;
   }
 
-  .word-highlight-word--current {
-    color: #ffd400;
+  // renderWordHighlightLine() injects this span via raw innerHTML rather than
+  // Angular's renderer/template, so it never gets the scoped _ngcontent
+  // attribute emulated encapsulation relies on - ::ng-deep is required here
+  // for the same reason it's needed for .vjs-text-track-display above.
+  ::ng-deep .word-highlight-word--current {
+    color: #fff;
     font-weight: 700;
   }
 }

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -213,8 +213,12 @@ div[data-marker-key] {
 // rather than depending on a one-time load check.
 // video.js creates this element itself (bypassing Angular's renderer), so it
 // never carries the emulated-encapsulation content attribute - ::ng-deep is
-// required for this rule to match it.
-::ng-deep .video-js.word-highlight-active .vjs-text-track-display {
+// required for this rule to match it. The :host prefix is required too -
+// without it Angular strips ::ng-deep down to a fully global, unscoped rule,
+// which (since this ships as both an Angular library and a web component
+// embedded in host apps) would leak this !important rule to every other
+// video.js instance on the host page, not just this component's own player.
+:host ::ng-deep .video-js.word-highlight-active .vjs-text-track-display {
   display: none !important;
 }
 

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -201,6 +201,58 @@ div[data-marker-key] {
   margin-left: 0.7% !important;
 }
 
-.vjs-texttrack-settings { // To do because we are disabled this feature and there is enhancement needed based on feture and requirements  
+.vjs-texttrack-settings { // To do because we are disabled this feature and there is enhancement needed based on feture and requirements
   display: none;
+}
+
+// Only hidden while the word-highlight overlay actually has a word to show
+// right now - showWordHighlightOverlay is recomputed on every timeupdate/seek
+// tick (see updateWordHighlightOverlay/rebuildWordHighlightAt), so content
+// without a wordByWordUrl, or where the word-level VTT is missing/broken/only
+// partially covers the video, continuously falls back to native captions
+// rather than depending on a one-time load check.
+// video.js creates this element itself (bypassing Angular's renderer), so it
+// never carries the emulated-encapsulation content attribute - ::ng-deep is
+// required for this rule to match it.
+::ng-deep .video-js.word-highlight-active .vjs-text-track-display {
+  display: none !important;
+}
+
+// Sibling of <video>, positioned against the same ancestor
+// (.sunbird-video-player-container, position:relative) that
+// .player-for-back-ward-controls above already uses to align exactly to the
+// video's box - percentage-based bottom/font-size keep it proportional to
+// that box without needing to live inside video.js's own DOM (which strips
+// unrecognized children when it replaces the <video> tag with its tech
+// element - do not move this element inside <video>, see PR discussion).
+.word-highlight-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 12%;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 3;
+
+  &--hidden {
+    display: none;
+  }
+
+  span {
+    max-width: 90%;
+    padding: 0.3em 0.6em;
+    background: rgba(0, 0, 0, 0.75);
+    color: #fff;
+    font-size: clamp(0.875rem, 2.2vw, 1.5rem);
+    font-weight: 400;
+    line-height: 1.4;
+    border-radius: 0.2em;
+    text-align: center;
+  }
+
+  .word-highlight-word--current {
+    color: #ffd400;
+    font-weight: 700;
+  }
 }

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
@@ -353,8 +353,8 @@ describe('VideoPlayerComponent', () => {
     const transcripts = [{ language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', wordByWordUrl: 'en-word.vtt' }];
     (component as any).attachTranscriptTracks(transcripts);
     expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(2);
-    expect((component as any).attachedTextTracks.get('captions|en')).toBe(captionsTrack.track);
-    expect((component as any).attachedTextTracks.get('metadata|en')).toBe(metadataTrack.track);
+    expect((component as any).attachedTextTracks.get('captions|en|en.vtt')).toBe(captionsTrack.track);
+    expect((component as any).attachedTextTracks.get('metadata|en|en-word.vtt')).toBe(metadataTrack.track);
   });
 
   it('should not attach a metadata track when wordByWordUrl is absent', () => {
@@ -364,16 +364,19 @@ describe('VideoPlayerComponent', () => {
     };
     (component as any).attachTranscriptTracks([{ language: 'English', languageCode: 'en', artifactUrl: 'en.vtt' }]);
     expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(1);
-    expect((component as any).attachedTextTracks.has('metadata|en')).toBeFalsy();
+    expect(Array.from((component as any).attachedTextTracks.keys()).some((k: string) => k.startsWith('metadata|'))).toBeFalsy();
   });
 
-  it('should mark the default transcript track as showing', () => {
+  it('should mark the default transcript track as showing and disable other showing captions tracks', () => {
     const captionsTrack = { track: { mode: 'disabled' } };
+    const otherShowingTrack: any = { kind: 'captions', mode: 'showing' };
     component.player = {
-      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(captionsTrack)
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(captionsTrack),
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([otherShowingTrack])
     };
     (component as any).addTranscriptTrack('captions', { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', default: true });
     expect(captionsTrack.track.mode).toBe('showing');
+    expect(otherShowingTrack.mode).toBe('disabled');
   });
 
   it('should not throw when addRemoteTextTrack returns undefined because the tech is not ready yet', () => {
@@ -388,8 +391,9 @@ describe('VideoPlayerComponent', () => {
   it('should remove stale tracks and add new ones when transcripts are synced', () => {
     const oldTrack = { mode: 'showing' };
     const newCaptionsTrack = { track: { mode: 'disabled' } };
-    (component as any).attachedTextTracks.set('captions|fr', oldTrack);
+    (component as any).attachedTextTracks.set('captions|fr|fr.vtt', oldTrack);
     component.config = { transcripts: [] };
+    component.viewerService.metaData = { transcripts: [] };
     spyOn(component.viewerService, 'handleTranscriptsData').and.returnValue([
       { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', identifier: 'en-id' }
     ]);
@@ -398,10 +402,46 @@ describe('VideoPlayerComponent', () => {
       addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(newCaptionsTrack),
       textTracks: jasmine.createSpy('textTracks').and.returnValue([])
     };
-    (component as any).syncTranscriptTracks([]);
+    (component as any).syncTranscriptTracks();
     expect(component.player.removeRemoteTextTrack).toHaveBeenCalledWith(oldTrack);
-    expect((component as any).attachedTextTracks.has('captions|fr')).toBeFalsy();
-    expect((component as any).attachedTextTracks.get('captions|en')).toBe(newCaptionsTrack.track);
+    expect((component as any).attachedTextTracks.has('captions|fr|fr.vtt')).toBeFalsy();
+    expect((component as any).attachedTextTracks.get('captions|en|en.vtt')).toBe(newCaptionsTrack.track);
+  });
+
+  it('should preserve accumulated telemetry transcript history across a sync', () => {
+    (component as any).attachedTextTracks.set('captions|fr|fr.vtt', { mode: 'showing' });
+    component.config = { transcripts: [] };
+    component.viewerService.metaData = { transcripts: ['en', 'fr', 'off'] };
+    spyOn(component.viewerService, 'handleTranscriptsData').and.callFake((selected) => {
+      // Simulate the real method's side effect of overwriting metaData.transcripts.
+      component.viewerService.metaData.transcripts = selected;
+      return [{ language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', identifier: 'en-id' }];
+    });
+    component.player = {
+      removeRemoteTextTrack: jasmine.createSpy('removeRemoteTextTrack'),
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue({ track: { mode: 'disabled' } }),
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([])
+    };
+    (component as any).syncTranscriptTracks();
+    expect(component.viewerService.metaData.transcripts).toEqual(['en', 'fr', 'off']);
+  });
+
+  it('should deactivate the word-highlight overlay when its active track is removed during a sync', () => {
+    const activeTrack = { mode: 'hidden' };
+    (component as any).attachedTextTracks.set('metadata|fr|fr.vtt', activeTrack);
+    (component as any).activeWordTrack = activeTrack;
+    (component as any).activeWordTrackOwned = true;
+    component.config = { transcripts: [] };
+    component.viewerService.metaData = { transcripts: [] };
+    spyOn(component.viewerService, 'handleTranscriptsData').and.returnValue([]);
+    component.player = {
+      removeRemoteTextTrack: jasmine.createSpy('removeRemoteTextTrack'),
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([])
+    };
+    (component as any).syncTranscriptTracks();
+    expect(activeTrack.mode).toBe('disabled');
+    expect((component as any).activeWordTrack).toBeNull();
+    expect(component.player.removeRemoteTextTrack).toHaveBeenCalledWith(activeTrack);
   });
 
   it('should activate the matching metadata track for word-highlight overlay', () => {
@@ -432,8 +472,9 @@ describe('VideoPlayerComponent', () => {
     expect(component.player.removeClass).toHaveBeenCalledWith('word-highlight-active');
   });
 
-  it('should reuse the same-language captions track when no distinct metadata track exists', () => {
+  it('should reuse the same-language captions track when wordByWordUrl equals artifactUrl and no distinct metadata track exists', () => {
     const captionsTrack: any = { kind: 'captions', language: 'en', mode: 'showing', cues: [] };
+    component.transcripts = [{ languageCode: 'en', artifactUrl: 'en.vtt', wordByWordUrl: 'en.vtt' }];
     component.player = {
       textTracks: jasmine.createSpy('textTracks').and.returnValue([captionsTrack]),
       currentTime: jasmine.createSpy('currentTime').and.returnValue(0),
@@ -448,6 +489,21 @@ describe('VideoPlayerComponent', () => {
     expect(captionsTrack.mode).toBe('showing');
   });
 
+  it('should never arm the overlay off the captions track for content with no wordByWordUrl at all', () => {
+    const captionsTrack: any = { kind: 'captions', language: 'en', mode: 'showing', cues: [] };
+    // No wordByWordUrl anywhere - today's ordinary content with plain captions.
+    component.transcripts = [{ languageCode: 'en', artifactUrl: 'en.vtt' }];
+    component.player = {
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([captionsTrack]),
+      currentTime: jasmine.createSpy('currentTime').and.returnValue(0),
+      addClass: jasmine.createSpy('addClass'),
+      removeClass: jasmine.createSpy('removeClass')
+    };
+    (component as any).activateWordHighlightTrack('en');
+    expect((component as any).activeWordTrack).toBeNull();
+    expect(component.player.addClass).not.toHaveBeenCalledWith('word-highlight-active');
+  });
+
   it('should not fetch a distinct metadata track when wordByWordUrl equals artifactUrl', () => {
     const captionsTrack = { track: { mode: 'disabled' } };
     component.player = {
@@ -457,7 +513,7 @@ describe('VideoPlayerComponent', () => {
       { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', wordByWordUrl: 'en.vtt' }
     ]);
     expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(1);
-    expect((component as any).attachedTextTracks.has('metadata|en')).toBeFalsy();
+    expect(Array.from((component as any).attachedTextTracks.keys()).some((k: string) => k.startsWith('metadata|'))).toBeFalsy();
   });
 
   it('should accumulate consecutive word cues within the gap and character thresholds', () => {

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
@@ -214,6 +214,9 @@ describe('VideoPlayerComponent', () => {
       currentTime: jasmine.createSpy('currentTime'),
       isFullscreen: jasmine.createSpy('isFullscreen'),
       duration: jasmine.createSpy('duration').and.returnValue(1290),
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([]),
+      addClass: jasmine.createSpy('addClass'),
+      removeClass: jasmine.createSpy('removeClass'),
       on: jasmine.createSpy('on').and.callFake((event, callback) => {
         expect(typeof callback).toBe('function');
         callback('pause', 'successResponse');
@@ -299,6 +302,9 @@ describe('VideoPlayerComponent', () => {
     component.viewerService.metaData = { transcripts: ['en'] };
     component.player = {
        currentTime: jasmine.createSpy('currentTime').and.returnValue(2.230),
+       textTracks: jasmine.createSpy('textTracks').and.returnValue([]),
+       addClass: jasmine.createSpy('addClass'),
+       removeClass: jasmine.createSpy('removeClass'),
      };
     const track =  { artifactUrl: 'https://cdn.jsdelivr.net/gh/tombyrer/videojs-transcript-click@1.0/demo/captions.sv.vtt',
       languageCode: 'bn' };
@@ -334,5 +340,151 @@ describe('VideoPlayerComponent', () => {
     component.ngOnChanges(mockData.changesForBlank);
     expect(component.pause).not.toHaveBeenCalled();
     expect(component.play).not.toHaveBeenCalled();
+  });
+
+  it('should attach captions and metadata tracks for transcripts with wordByWordUrl', () => {
+    const captionsTrack = { track: { mode: 'disabled' } };
+    const metadataTrack = { track: { mode: 'disabled' } };
+    component.player = {
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.callFake((opts) => {
+        return opts.kind === 'captions' ? captionsTrack : metadataTrack;
+      })
+    };
+    const transcripts = [{ language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', wordByWordUrl: 'en-word.vtt' }];
+    (component as any).attachTranscriptTracks(transcripts);
+    expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(2);
+    expect((component as any).attachedTextTracks.get('captions|en')).toBe(captionsTrack.track);
+    expect((component as any).attachedTextTracks.get('metadata|en')).toBe(metadataTrack.track);
+  });
+
+  it('should not attach a metadata track when wordByWordUrl is absent', () => {
+    const captionsTrack = { track: { mode: 'disabled' } };
+    component.player = {
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(captionsTrack)
+    };
+    (component as any).attachTranscriptTracks([{ language: 'English', languageCode: 'en', artifactUrl: 'en.vtt' }]);
+    expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(1);
+    expect((component as any).attachedTextTracks.has('metadata|en')).toBeFalsy();
+  });
+
+  it('should mark the default transcript track as showing', () => {
+    const captionsTrack = { track: { mode: 'disabled' } };
+    component.player = {
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(captionsTrack)
+    };
+    (component as any).addTranscriptTrack('captions', { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', default: true });
+    expect(captionsTrack.track.mode).toBe('showing');
+  });
+
+  it('should not throw when addRemoteTextTrack returns undefined because the tech is not ready yet', () => {
+    component.player = {
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(undefined)
+    };
+    expect(() => (component as any).addTranscriptTrack('captions', { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt' }))
+      .not.toThrow();
+    expect((component as any).attachedTextTracks.size).toBe(0);
+  });
+
+  it('should remove stale tracks and add new ones when transcripts are synced', () => {
+    const oldTrack = { mode: 'showing' };
+    const newCaptionsTrack = { track: { mode: 'disabled' } };
+    (component as any).attachedTextTracks.set('captions|fr', oldTrack);
+    component.config = { transcripts: [] };
+    spyOn(component.viewerService, 'handleTranscriptsData').and.returnValue([
+      { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', identifier: 'en-id' }
+    ]);
+    component.player = {
+      removeRemoteTextTrack: jasmine.createSpy('removeRemoteTextTrack'),
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(newCaptionsTrack),
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([])
+    };
+    (component as any).syncTranscriptTracks([]);
+    expect(component.player.removeRemoteTextTrack).toHaveBeenCalledWith(oldTrack);
+    expect((component as any).attachedTextTracks.has('captions|fr')).toBeFalsy();
+    expect((component as any).attachedTextTracks.get('captions|en')).toBe(newCaptionsTrack.track);
+  });
+
+  it('should activate the matching metadata track for word-highlight overlay', () => {
+    const wordTrack: any = { kind: 'metadata', language: 'en', mode: 'disabled', cues: [] };
+    component.player = {
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([wordTrack]),
+      currentTime: jasmine.createSpy('currentTime').and.returnValue(0),
+      addClass: jasmine.createSpy('addClass'),
+      removeClass: jasmine.createSpy('removeClass')
+    };
+    (component as any).activateWordHighlightTrack('en');
+    expect((component as any).activeWordTrack).toBe(wordTrack);
+    expect(wordTrack.mode).toBe('hidden');
+  });
+
+  it('should deactivate the active word-highlight track', () => {
+    const wordTrack: any = { mode: 'hidden' };
+    (component as any).activeWordTrack = wordTrack;
+    (component as any).showWordHighlightOverlay = true;
+    component.player = {
+      removeClass: jasmine.createSpy('removeClass'),
+      addClass: jasmine.createSpy('addClass')
+    };
+    (component as any).deactivateWordHighlightTrack();
+    expect(wordTrack.mode).toBe('disabled');
+    expect((component as any).activeWordTrack).toBeNull();
+    expect(component.player.removeClass).toHaveBeenCalledWith('word-highlight-active');
+  });
+
+  it('should accumulate consecutive word cues within the gap and character thresholds', () => {
+    const cues = [
+      { startTime: 0, endTime: 0.2, text: 'Hello' },
+      { startTime: 0.25, endTime: 0.5, text: 'world' }
+    ];
+    (component as any).activeWordTrack = { cues };
+    component.player = { addClass: jasmine.createSpy('addClass'), removeClass: jasmine.createSpy('removeClass') };
+    (component as any).updateWordHighlightOverlay(0.5);
+    expect((component as any).wordHighlightLineWords).toEqual(['Hello', 'world']);
+  });
+
+  it('should clear the accumulated line when the gap between cues exceeds the threshold', () => {
+    const cues = [
+      { startTime: 0, endTime: 0.2, text: 'Hello' },
+      { startTime: 2, endTime: 2.3, text: 'world' }
+    ];
+    (component as any).activeWordTrack = { cues };
+    component.player = { addClass: jasmine.createSpy('addClass'), removeClass: jasmine.createSpy('removeClass') };
+    (component as any).updateWordHighlightOverlay(2.3);
+    expect((component as any).wordHighlightLineWords).toEqual(['world']);
+  });
+
+  it('should clear the accumulated line when the character cap is exceeded', () => {
+    (component as any).wordHighlightMaxLineCharacters = 10;
+    const cues = [
+      { startTime: 0, endTime: 0.1, text: 'Hello' },
+      { startTime: 0.15, endTime: 0.3, text: 'World' },
+      { startTime: 0.35, endTime: 0.5, text: 'Again' }
+    ];
+    (component as any).activeWordTrack = { cues };
+    component.player = { addClass: jasmine.createSpy('addClass'), removeClass: jasmine.createSpy('removeClass') };
+    (component as any).updateWordHighlightOverlay(0.5);
+    expect((component as any).wordHighlightLineWords).toEqual(['Again']);
+  });
+
+  it('should reconstruct the current line backward from currentTime on seek', () => {
+    const cues = [
+      { startTime: 0, endTime: 0.2, text: 'Hello' },
+      { startTime: 0.25, endTime: 0.5, text: 'world' },
+      { startTime: 3, endTime: 3.2, text: 'later' }
+    ];
+    (component as any).activeWordTrack = { cues };
+    component.player = { addClass: jasmine.createSpy('addClass'), removeClass: jasmine.createSpy('removeClass') };
+    (component as any).rebuildWordHighlightAt(0.5);
+    expect((component as any).wordHighlightLineWords).toEqual(['Hello', 'world']);
+  });
+
+  it('should show nothing after seeking past the last cue beyond the gap threshold', () => {
+    const cues = [
+      { startTime: 0, endTime: 0.2, text: 'Hello' }
+    ];
+    (component as any).activeWordTrack = { cues };
+    component.player = { addClass: jasmine.createSpy('addClass'), removeClass: jasmine.createSpy('removeClass') };
+    (component as any).rebuildWordHighlightAt(5);
+    expect((component as any).wordHighlightLineWords).toEqual([]);
   });
 });

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.spec.ts
@@ -420,6 +420,7 @@ describe('VideoPlayerComponent', () => {
   it('should deactivate the active word-highlight track', () => {
     const wordTrack: any = { mode: 'hidden' };
     (component as any).activeWordTrack = wordTrack;
+    (component as any).activeWordTrackOwned = true;
     (component as any).showWordHighlightOverlay = true;
     component.player = {
       removeClass: jasmine.createSpy('removeClass'),
@@ -429,6 +430,34 @@ describe('VideoPlayerComponent', () => {
     expect(wordTrack.mode).toBe('disabled');
     expect((component as any).activeWordTrack).toBeNull();
     expect(component.player.removeClass).toHaveBeenCalledWith('word-highlight-active');
+  });
+
+  it('should reuse the same-language captions track when no distinct metadata track exists', () => {
+    const captionsTrack: any = { kind: 'captions', language: 'en', mode: 'showing', cues: [] };
+    component.player = {
+      textTracks: jasmine.createSpy('textTracks').and.returnValue([captionsTrack]),
+      currentTime: jasmine.createSpy('currentTime').and.returnValue(0),
+      addClass: jasmine.createSpy('addClass'),
+      removeClass: jasmine.createSpy('removeClass')
+    };
+    (component as any).activateWordHighlightTrack('en');
+    expect((component as any).activeWordTrack).toBe(captionsTrack);
+    expect((component as any).activeWordTrackOwned).toBeFalsy();
+    // Mode must be left alone - native captions rendering depends on it
+    // staying 'showing', unlike a dedicated metadata track we own.
+    expect(captionsTrack.mode).toBe('showing');
+  });
+
+  it('should not fetch a distinct metadata track when wordByWordUrl equals artifactUrl', () => {
+    const captionsTrack = { track: { mode: 'disabled' } };
+    component.player = {
+      addRemoteTextTrack: jasmine.createSpy('addRemoteTextTrack').and.returnValue(captionsTrack)
+    };
+    (component as any).attachTranscriptTracks([
+      { language: 'English', languageCode: 'en', artifactUrl: 'en.vtt', wordByWordUrl: 'en.vtt' }
+    ]);
+    expect(component.player.addRemoteTextTrack).toHaveBeenCalledTimes(1);
+    expect((component as any).attachedTextTracks.has('metadata|en')).toBeFalsy();
   });
 
   it('should accumulate consecutive word cues within the gap and character thresholds', () => {

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -49,6 +49,11 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   disablePictureInPicture = false;
   showWordHighlightOverlay = false;
   private activeWordTrack: any = null;
+  // True when activeWordTrack is a dedicated metadata track we control the
+  // mode of; false when it's a shared captions track (reused because
+  // wordByWordUrl equals artifactUrl) whose mode must be left alone since
+  // native captions rendering depends on it staying 'showing'.
+  private activeWordTrackOwned = false;
   private wordHighlightCues: any[] = [];
   private wordHighlightCueIndex = 0;
   private wordHighlightLineWords: string[] = [];
@@ -355,10 +360,18 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     this.attachedTextTracks.set(this.trackKey(kind, trans.languageCode), trackEl.track);
   }
 
+  // A distinct metadata track (and its own fetch) is only needed when
+  // wordByWordUrl genuinely points at a different file than the captions
+  // track - when they're the same URL, the captions track's own cues are
+  // reused for the overlay instead of fetching an identical copy twice.
+  private needsDistinctWordTrack(trans: any): boolean {
+    return !!trans.wordByWordUrl && trans.wordByWordUrl !== trans.artifactUrl;
+  }
+
   private attachTranscriptTracks(transcripts: any[]) {
     (transcripts || []).forEach((trans) => {
       this.addTranscriptTrack('captions', trans);
-      if (trans.wordByWordUrl) {
+      if (this.needsDistinctWordTrack(trans)) {
         this.addTranscriptTrack('metadata', trans);
       }
     });
@@ -387,7 +400,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     const desiredKeys = new Set<string>();
     (newTranscripts || []).forEach((trans) => {
       desiredKeys.add(this.trackKey('captions', trans.languageCode));
-      if (trans.wordByWordUrl) {
+      if (this.needsDistinctWordTrack(trans)) {
         desiredKeys.add(this.trackKey('metadata', trans.languageCode));
       }
     });
@@ -403,11 +416,11 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       if (!this.attachedTextTracks.has(this.trackKey('captions', trans.languageCode))) {
         this.addTranscriptTrack('captions', trans);
       }
-      if (trans.wordByWordUrl && !this.attachedTextTracks.has(this.trackKey('metadata', trans.languageCode))) {
+      if (this.needsDistinctWordTrack(trans) && !this.attachedTextTracks.has(this.trackKey('metadata', trans.languageCode))) {
         this.addTranscriptTrack('metadata', trans);
-        if (!this.activeWordTrack && showingLanguage === trans.languageCode) {
-          this.activateWordHighlightTrack(trans.languageCode);
-        }
+      }
+      if (trans.wordByWordUrl && !this.activeWordTrack && showingLanguage === trans.languageCode) {
+        this.activateWordHighlightTrack(trans.languageCode);
       }
     });
     this.transcripts = newTranscripts;
@@ -450,26 +463,45 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   // no special-case detection: native captions just keep showing whenever the
   // overlay has nothing, with no timers or video.js-internal load/error
   // events involved.
-  private activateWordHighlightTrack(languageCode: string) {
+  // Prefers a dedicated metadata track for the language; falls back to the
+  // same-language captions track's own cues when no distinct wordByWordUrl
+  // was ever fetched (the common case - wordByWordUrl equals artifactUrl).
+  private findWordHighlightSource(languageCode: string): { track: any; owned: boolean } | null {
     const textTracks = this.player.textTracks();
-    let wordTrack = null;
+    let captionsTrack = null;
     for (let i = 0; i < textTracks.length; i++) {
       const track = textTracks[i];
-      if (track.kind === 'metadata' && track.language &&
-        track.language.toLowerCase() === languageCode.toLowerCase()) {
-        wordTrack = track;
-        break;
+      if (!track.language || track.language.toLowerCase() !== languageCode.toLowerCase()) {
+        continue;
+      }
+      if (track.kind === 'metadata') {
+        return { track, owned: true };
+      }
+      if (track.kind === 'captions' || track.kind === 'subtitles') {
+        captionsTrack = track;
       }
     }
-    if (this.activeWordTrack && this.activeWordTrack !== wordTrack) {
+    return captionsTrack ? { track: captionsTrack, owned: false } : null;
+  }
+
+  private activateWordHighlightTrack(languageCode: string) {
+    const source = this.findWordHighlightSource(languageCode);
+    const wordTrack = source ? source.track : null;
+    if (this.activeWordTrack && this.activeWordTrack !== wordTrack && this.activeWordTrackOwned) {
       this.activeWordTrack.mode = 'disabled';
     }
     this.activeWordTrack = wordTrack;
+    this.activeWordTrackOwned = !!source && source.owned;
     this.resetWordHighlightState();
     if (!wordTrack) {
       return;
     }
-    wordTrack.mode = 'hidden';
+    // Only take ownership of the track's mode when it's a dedicated metadata
+    // track nothing else depends on - when reusing the captions track, its
+    // mode must stay whatever native caption rendering already set it to.
+    if (this.activeWordTrackOwned) {
+      wordTrack.mode = 'hidden';
+    }
     // In case cues are already loaded (e.g. re-enabling a track the user had
     // on before) and playback is already mid-video, position the overlay
     // immediately instead of waiting for the next timeupdate tick to sweep
@@ -478,10 +510,11 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   }
 
   private deactivateWordHighlightTrack() {
-    if (this.activeWordTrack) {
+    if (this.activeWordTrack && this.activeWordTrackOwned) {
       this.activeWordTrack.mode = 'disabled';
     }
     this.activeWordTrack = null;
+    this.activeWordTrackOwned = false;
     this.resetWordHighlightState();
     this.renderWordHighlightLine();
   }
@@ -594,23 +627,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
 
   private renderWordHighlightLine() {
     if (!this.wordHighlightLine) { return; }
-    // Only bold the last word when there are other words on the same line to
-    // contrast it against - for sentence-level VTTs (no real word-level
-    // timing) each line is just a single whole-sentence cue, so marking that
-    // sole item "current" would bold the entire sentence instead of
-    // highlighting anything meaningful.
-    const highlightLast = this.wordHighlightLineWords.length > 1;
-    this.wordHighlightLine.nativeElement.innerHTML = this.wordHighlightLineWords
-      .map((word, i) => (highlightLast && i === this.wordHighlightLineWords.length - 1)
-        ? `<span class="word-highlight-word--current">${this.escapeHtml(word)}</span>`
-        : this.escapeHtml(word))
-      .join(' ');
-  }
-
-  private escapeHtml(text: string): string {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
+    this.wordHighlightLine.nativeElement.textContent = this.wordHighlightLineWords.join(' ');
   }
 
   toggleForwardRewindButton() {

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -54,6 +54,14 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   // wordByWordUrl equals artifactUrl) whose mode must be left alone since
   // native captions rendering depends on it staying 'showing'.
   private activeWordTrackOwned = false;
+  // Guards against telemetry double-firing: trackTranscriptEvent's 'change'
+  // listener re-triggers subtitleChanged on ANY textTracks mode change, not
+  // just a viewer-driven CC-menu pick - so our own internal mode writes
+  // (forcing a default track to show, disabling a sibling, arming/disarming
+  // the overlay's metadata track) would otherwise cause a second, spurious
+  // handleEventsForTranscripts call ~10ms later, duplicating HEARTBEAT/
+  // INTERACT events. Set true around any mode write we make ourselves.
+  private suppressTrackChangeTelemetry = false;
   private wordHighlightCues: any[] = [];
   private wordHighlightCueIndex = 0;
   private wordHighlightLineWords: string[] = [];
@@ -127,8 +135,8 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       this.player.ready(() => {
         this.attachTranscriptTracks(this.transcripts);
       });
-      this.transcriptsUpdatedSubscription = this.viewerService.transcriptsUpdated.subscribe((updated) => {
-        this.syncTranscriptTracks(updated);
+      this.transcriptsUpdatedSubscription = this.viewerService.transcriptsUpdated.subscribe(() => {
+        this.syncTranscriptTracks();
       });
       const markers = this.viewerService.getMarkers();
 
@@ -314,7 +322,11 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   trackTranscriptEvent() {
     let timeout;
     const player = this.player;
+    const component = this;
     this.player.textTracks().on('change', function action(event) {
+      if (component.suppressTrackChangeTelemetry) {
+        return;
+      }
       clearTimeout(timeout);
       let transcriptObject = {};
       this.tracks_.filter((track) => {
@@ -328,8 +340,39 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       }, 10);
     });
   }
-  private trackKey(kind: string, languageCode: string): string {
-    return `${kind}|${languageCode}`;
+
+  // Wraps a mode write we make ourselves so trackTranscriptEvent's 'change'
+  // listener (above) ignores the resulting re-entrant event instead of
+  // treating it as a viewer-driven caption switch. Held slightly longer than
+  // that listener's own 10ms debounce so our write can never race it.
+  private withSuppressedTrackChangeTelemetry(write: () => void) {
+    this.suppressTrackChangeTelemetry = true;
+    write();
+    setTimeout(() => { this.suppressTrackChangeTelemetry = false; }, 20);
+  }
+  // Includes the resolved src so that a hot-reload payload changing a
+  // language's artifactUrl/wordByWordUrl (a corrected or regenerated
+  // transcript) produces a different key - which makes the reconciliation
+  // loop in syncTranscriptTracks naturally treat it as remove-old + add-new
+  // instead of silently keeping the stale track attached.
+  private trackKey(kind: string, languageCode: string, src: string): string {
+    return `${kind}|${languageCode}|${src}`;
+  }
+
+  // Ensures only one captions/subtitles track is ever 'showing' at a time.
+  // Needed because forcing a newly-arrived default track to 'showing' below
+  // bypasses the CC menu's own mutual-exclusivity handling - without this, a
+  // late-arriving default language (e.g. a hot-reloaded transcript the host
+  // marked default) could end up showing alongside a track the viewer had
+  // already selected, rendering two overlapping captions at once.
+  private disableOtherCaptionsTracks(exceptTrack: any) {
+    const textTracks = this.player.textTracks();
+    for (let i = 0; i < textTracks.length; i++) {
+      const track = textTracks[i];
+      if (track !== exceptTrack && (track.kind === 'captions' || track.kind === 'subtitles') && track.mode === 'showing') {
+        this.withSuppressedTrackChangeTelemetry(() => { track.mode = 'disabled'; });
+      }
+    }
   }
 
   private addTranscriptTrack(kind: 'captions' | 'metadata', trans: any) {
@@ -355,9 +398,12 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     // be forced here explicitly or the "default" language would never show
     // without the viewer manually opening the CC menu.
     if (isDefault && trackEl.track) {
-      trackEl.track.mode = 'showing';
+      if (kind === 'captions') {
+        this.disableOtherCaptionsTracks(trackEl.track);
+      }
+      this.withSuppressedTrackChangeTelemetry(() => { trackEl.track.mode = 'showing'; });
     }
-    this.attachedTextTracks.set(this.trackKey(kind, trans.languageCode), trackEl.track);
+    this.attachedTextTracks.set(this.trackKey(kind, trans.languageCode, src), trackEl.track);
   }
 
   // A distinct metadata track (and its own fetch) is only needed when
@@ -377,12 +423,16 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     });
   }
 
+  // Lower-cased for consistency with findWordHighlightSource's comparison -
+  // both ultimately originate from the same trans.languageCode, but nothing
+  // guarantees the browser/video.js won't normalize TextTrack.language
+  // differently than the raw config value.
   private findShowingCaptionsLanguage(): string {
     const tracks = this.player.textTracks();
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
       if ((track.kind === 'captions' || track.kind === 'subtitles') && track.mode === 'showing') {
-        return track.language;
+        return track.language ? track.language.toLowerCase() : track.language;
       }
     }
     return null;
@@ -394,32 +444,50 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   // mounted and playing. Removes tracks no longer present, adds new ones,
   // and re-arms the word-highlight overlay if a wordByWordUrl just became
   // available for the language currently showing.
-  private syncTranscriptTracks(rawTranscripts: any[]) {
+  private syncTranscriptTracks() {
     const selected = _.get(this.config, 'transcripts') || [];
+    // handleTranscriptsData() also overwrites metaData.transcripts (the
+    // telemetry record of every language the viewer has switched to/from
+    // this session) with just `selected` - fine for the very first call from
+    // ngOnInit, but calling it again here would wipe that accumulated
+    // history on every hot reload. Snapshot and restore around the call so
+    // only the derived `default` flags are picked up, not the telemetry
+    // side effect.
+    const metaDataTranscriptsSnapshot = [...(this.viewerService.metaData.transcripts || [])];
     const newTranscripts = this.viewerService.handleTranscriptsData(selected);
+    this.viewerService.metaData.transcripts = metaDataTranscriptsSnapshot;
     const desiredKeys = new Set<string>();
     (newTranscripts || []).forEach((trans) => {
-      desiredKeys.add(this.trackKey('captions', trans.languageCode));
+      desiredKeys.add(this.trackKey('captions', trans.languageCode, trans.artifactUrl));
       if (this.needsDistinctWordTrack(trans)) {
-        desiredKeys.add(this.trackKey('metadata', trans.languageCode));
+        desiredKeys.add(this.trackKey('metadata', trans.languageCode, trans.wordByWordUrl));
       }
     });
     Array.from(this.attachedTextTracks.keys()).forEach((key) => {
       if (!desiredKeys.has(key)) {
         const track = this.attachedTextTracks.get(key);
+        // The track being removed may be the one currently driving the
+        // overlay (host pushed a payload that dropped this language) -
+        // deactivate first so activeWordTrack/wordHighlightCues don't keep
+        // referencing a detached track and rendering stale text forever.
+        if (track === this.activeWordTrack) {
+          this.deactivateWordHighlightTrack();
+        }
         this.player.removeRemoteTextTrack(track);
         this.attachedTextTracks.delete(key);
       }
     });
     const showingLanguage = this.findShowingCaptionsLanguage();
     (newTranscripts || []).forEach((trans) => {
-      if (!this.attachedTextTracks.has(this.trackKey('captions', trans.languageCode))) {
+      if (!this.attachedTextTracks.has(this.trackKey('captions', trans.languageCode, trans.artifactUrl))) {
         this.addTranscriptTrack('captions', trans);
       }
-      if (this.needsDistinctWordTrack(trans) && !this.attachedTextTracks.has(this.trackKey('metadata', trans.languageCode))) {
+      if (this.needsDistinctWordTrack(trans) &&
+        !this.attachedTextTracks.has(this.trackKey('metadata', trans.languageCode, trans.wordByWordUrl))) {
         this.addTranscriptTrack('metadata', trans);
       }
-      if (trans.wordByWordUrl && !this.activeWordTrack && showingLanguage === trans.languageCode) {
+      const languageCode = trans.languageCode ? trans.languageCode.toLowerCase() : trans.languageCode;
+      if (trans.wordByWordUrl && !this.activeWordTrack && showingLanguage === languageCode) {
         this.activateWordHighlightTrack(trans.languageCode);
       }
     });
@@ -464,8 +532,11 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   // overlay has nothing, with no timers or video.js-internal load/error
   // events involved.
   // Prefers a dedicated metadata track for the language; falls back to the
-  // same-language captions track's own cues when no distinct wordByWordUrl
-  // was ever fetched (the common case - wordByWordUrl equals artifactUrl).
+  // same-language captions track's own cues ONLY when this transcript
+  // actually declared wordByWordUrl pointing at that same file (the "no
+  // second fetch" dedup case) - content with no wordByWordUrl at all never
+  // opted into word-highlight, so it must fall through to null and let
+  // native captions render completely untouched.
   private findWordHighlightSource(languageCode: string): { track: any; owned: boolean } | null {
     const textTracks = this.player.textTracks();
     let captionsTrack = null;
@@ -481,14 +552,20 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
         captionsTrack = track;
       }
     }
-    return captionsTrack ? { track: captionsTrack, owned: false } : null;
+    if (!captionsTrack) {
+      return null;
+    }
+    const trans = _.find(this.transcripts, (t: any) =>
+      t.languageCode && t.languageCode.toLowerCase() === languageCode.toLowerCase());
+    const reusesCaptionsFile = trans && trans.wordByWordUrl && trans.wordByWordUrl === trans.artifactUrl;
+    return reusesCaptionsFile ? { track: captionsTrack, owned: false } : null;
   }
 
   private activateWordHighlightTrack(languageCode: string) {
     const source = this.findWordHighlightSource(languageCode);
     const wordTrack = source ? source.track : null;
     if (this.activeWordTrack && this.activeWordTrack !== wordTrack && this.activeWordTrackOwned) {
-      this.activeWordTrack.mode = 'disabled';
+      this.withSuppressedTrackChangeTelemetry(() => { this.activeWordTrack.mode = 'disabled'; });
     }
     this.activeWordTrack = wordTrack;
     this.activeWordTrackOwned = !!source && source.owned;
@@ -500,7 +577,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     // track nothing else depends on - when reusing the captions track, its
     // mode must stay whatever native caption rendering already set it to.
     if (this.activeWordTrackOwned) {
-      wordTrack.mode = 'hidden';
+      this.withSuppressedTrackChangeTelemetry(() => { wordTrack.mode = 'hidden'; });
     }
     // In case cues are already loaded (e.g. re-enabling a track the user had
     // on before) and playback is already mid-video, position the overlay
@@ -511,7 +588,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
 
   private deactivateWordHighlightTrack() {
     if (this.activeWordTrack && this.activeWordTrackOwned) {
-      this.activeWordTrack.mode = 'disabled';
+      this.withSuppressedTrackChangeTelemetry(() => { this.activeWordTrack.mode = 'disabled'; });
     }
     this.activeWordTrack = null;
     this.activeWordTrackOwned = false;

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -6,6 +6,7 @@ import * as _ from 'lodash-es';
 import videojs from 'video.js';
 import 'videojs-contrib-quality-levels';
 import videojshttpsourceselector from 'videojs-http-source-selector';
+import { Subscription } from 'rxjs';
 import { ViewerService } from '../../services/viewer.service';
 import { IAction } from '../../playerInterfaces';
 
@@ -32,6 +33,8 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   private unlistenTargetTouchStart: () => void;
   @ViewChild('target', { static: true }) target: ElementRef;
   @ViewChild('controlDiv', { static: true }) controlDiv: ElementRef;
+  @ViewChild('wordHighlightOverlay', { static: true }) wordHighlightOverlay: ElementRef;
+  @ViewChild('wordHighlightLine', { static: true }) wordHighlightLine: ElementRef;
   player: any;
   totalSeekedLength = 0;
   previousTime = 0;
@@ -44,6 +47,35 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   setMetaDataConfig = false;
   totalDuration = 0;
   disablePictureInPicture = false;
+  showWordHighlightOverlay = false;
+  private activeWordTrack: any = null;
+  private wordHighlightCues: any[] = [];
+  private wordHighlightCueIndex = 0;
+  private wordHighlightLineWords: string[] = [];
+  private wordHighlightLastCueEnd = 0;
+  private wordHighlightLineStart = 0;
+  // Configurable via config.wordHighlight - see ngOnInit.
+  private wordHighlightGapThresholdSeconds = 0.3;
+  // Independent ceiling on top of the gap-based clearing above - ASR-generated
+  // word-level VTTs can have zero gap between contiguous cues for an entire
+  // monologue, in which case the gap check alone never fires and the line
+  // grows without bound (observed with real word-by-word Urdu captions).
+  // Netflix's per-line character cap (~42) is used as that ceiling - a
+  // reading-speed-based duration cap was tried and reverted: it compares
+  // against elapsed *speech* time, which is inherently slower per-character
+  // than any reasonable reading speed, so it would clear the line almost
+  // immediately after every single word.
+  private wordHighlightMaxLineCharacters = 42;
+  // Tracks every <track> currently attached via player.addRemoteTextTrack(),
+  // keyed by `${kind}|${languageCode}`. video.js's removeRemoteTextTrack()
+  // only works on tracks added this way (not on statically-declared HTML
+  // <track> elements) - so ALL transcript tracks, including the first ones
+  // loaded, go through this same path. That's what makes it possible to
+  // cleanly add/remove tracks later when transcriptsUpdated fires (e.g. a
+  // transcript finishing generation while the player is already mounted),
+  // without duplicating or leaking tracks.
+  private attachedTextTracks = new Map<string, any>();
+  private transcriptsUpdatedSubscription: Subscription;
 
 
   constructor(public viewerService: ViewerService, private renderer2: Renderer2,
@@ -51,6 +83,8 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   ngOnInit() {
     this.disablePictureInPicture = _.get(this.config, 'disablePictureInPictureMode', false);
     this.transcripts = this.viewerService.handleTranscriptsData(_.get(this.config, 'transcripts') || []);
+    this.wordHighlightGapThresholdSeconds = _.get(this.config, 'wordHighlight.gapThresholdSeconds', 0.3);
+    this.wordHighlightMaxLineCharacters = _.get(this.config, 'wordHighlight.maxLineCharacters', 42);
   }
   ngAfterViewInit() {
     this.viewerService.getPlayerOptions().then(async (options) => {
@@ -82,6 +116,16 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       } as any);
       this.player.videojshttpsourceselector = videojshttpsourceselector;
       this.player.videojshttpsourceselector();
+      // player.addRemoteTextTrack() silently returns undefined if called
+      // before player.tech_ is attached - not guaranteed yet just because the
+      // videojs(...) promise above has resolved. player.ready() is the
+      // documented-safe point to call it.
+      this.player.ready(() => {
+        this.attachTranscriptTracks(this.transcripts);
+      });
+      this.transcriptsUpdatedSubscription = this.viewerService.transcriptsUpdated.subscribe((updated) => {
+        this.syncTranscriptTracks(updated);
+      });
       const markers = this.viewerService.getMarkers();
 
       if (markers && markers.length > 0) {
@@ -194,9 +238,13 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       'ratechange'];
 
     this.player.on('fullscreenchange', (data) => {
-      // This code is to show the controldiv in fullscreen mode
+      // This code is to show the controldiv (and the word-highlight overlay,
+      // for the same reason) in fullscreen mode - entering fullscreen only
+      // renders the fullscreen element and its descendants, and both of these
+      // are siblings of <video> rather than descendants of it.
       if (this.player.isFullscreen()) {
         this.target.nativeElement.parentNode.appendChild(this.controlDiv.nativeElement);
+        this.target.nativeElement.parentNode.appendChild(this.wordHighlightOverlay.nativeElement);
       }
       this.viewerService.raiseHeartBeatEvent('FULLSCREEN');
     });
@@ -229,12 +277,16 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       this.viewerService.currentlength = this.viewerService.metaData.currentDuration;
       this.totalSpentTime += new Date().getTime() - this.startTime;
       this.startTime = new Date().getTime();
+      this.updateWordHighlightOverlay(this.player.currentTime());
       const remainingTime = Math.floor(this.totalDuration - this.player.currentTime());
       if (remainingTime <= 0) {
             this.viewerService.metaData.currentDuration = 0;
             this.handleVideoControls({ type: 'ended' });
             this.viewerService.playerEvent.emit({ type: 'ended' });
       }
+    });
+    this.player.on('seeked', (data) => {
+      this.rebuildWordHighlightAt(this.player.currentTime());
     });
     this.player.on('subtitleChanged', (event, track) => {
       this.handleEventsForTranscripts(track);
@@ -272,6 +324,96 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       }, 10);
     });
   }
+  private trackKey(kind: string, languageCode: string): string {
+    return `${kind}|${languageCode}`;
+  }
+
+  private addTranscriptTrack(kind: 'captions' | 'metadata', trans: any) {
+    const src = kind === 'captions' ? trans.artifactUrl : trans.wordByWordUrl;
+    const sourceSuffix = trans.sourceLanguage ? ' (Original)' : '';
+    const label = kind === 'captions' ? `${trans.language}${sourceSuffix}` : `${trans.language} (word-by-word)`;
+    const isDefault = kind === 'captions' ? !!trans.default : false;
+    const trackEl = this.player.addRemoteTextTrack({
+      kind,
+      src,
+      srclang: trans.languageCode,
+      label,
+      default: isDefault
+    }, false);
+    if (!trackEl) {
+      return;
+    }
+    // The native `default` attribute is only auto-honored by the browser
+    // during a media element's INITIAL text-track processing. Tracks added
+    // imperatively via addRemoteTextTrack() after the player/tech is already
+    // set up (which is every track now, including the first ones - see the
+    // note on attachedTextTracks) don't get that automatic pass, so it has to
+    // be forced here explicitly or the "default" language would never show
+    // without the viewer manually opening the CC menu.
+    if (isDefault && trackEl.track) {
+      trackEl.track.mode = 'showing';
+    }
+    this.attachedTextTracks.set(this.trackKey(kind, trans.languageCode), trackEl.track);
+  }
+
+  private attachTranscriptTracks(transcripts: any[]) {
+    (transcripts || []).forEach((trans) => {
+      this.addTranscriptTrack('captions', trans);
+      if (trans.wordByWordUrl) {
+        this.addTranscriptTrack('metadata', trans);
+      }
+    });
+  }
+
+  private findShowingCaptionsLanguage(): string {
+    const tracks = this.player.textTracks();
+    for (let i = 0; i < tracks.length; i++) {
+      const track = tracks[i];
+      if ((track.kind === 'captions' || track.kind === 'subtitles') && track.mode === 'showing') {
+        return track.language;
+      }
+    }
+    return null;
+  }
+
+  // Reconciles the live player's attached tracks against a freshly-updated
+  // transcripts array (see ViewerService.transcriptsUpdated) - e.g. a
+  // transcript that finishes generating while the preview/player is already
+  // mounted and playing. Removes tracks no longer present, adds new ones,
+  // and re-arms the word-highlight overlay if a wordByWordUrl just became
+  // available for the language currently showing.
+  private syncTranscriptTracks(rawTranscripts: any[]) {
+    const selected = _.get(this.config, 'transcripts') || [];
+    const newTranscripts = this.viewerService.handleTranscriptsData(selected);
+    const desiredKeys = new Set<string>();
+    (newTranscripts || []).forEach((trans) => {
+      desiredKeys.add(this.trackKey('captions', trans.languageCode));
+      if (trans.wordByWordUrl) {
+        desiredKeys.add(this.trackKey('metadata', trans.languageCode));
+      }
+    });
+    Array.from(this.attachedTextTracks.keys()).forEach((key) => {
+      if (!desiredKeys.has(key)) {
+        const track = this.attachedTextTracks.get(key);
+        this.player.removeRemoteTextTrack(track);
+        this.attachedTextTracks.delete(key);
+      }
+    });
+    const showingLanguage = this.findShowingCaptionsLanguage();
+    (newTranscripts || []).forEach((trans) => {
+      if (!this.attachedTextTracks.has(this.trackKey('captions', trans.languageCode))) {
+        this.addTranscriptTrack('captions', trans);
+      }
+      if (trans.wordByWordUrl && !this.attachedTextTracks.has(this.trackKey('metadata', trans.languageCode))) {
+        this.addTranscriptTrack('metadata', trans);
+        if (!this.activeWordTrack && showingLanguage === trans.languageCode) {
+          this.activateWordHighlightTrack(trans.languageCode);
+        }
+      }
+    });
+    this.transcripts = newTranscripts;
+  }
+
   handleEventsForTranscripts(track) {
     let telemetryObject;
     if (!_.isEmpty(track)) {
@@ -287,6 +429,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       if (_.last(this.viewerService.metaData.transcripts) !== track.languageCode) {
         this.viewerService.metaData.transcripts.push(track.languageCode);
       }
+      this.activateWordHighlightTrack(track.languageCode);
     } else {
       telemetryObject = {
         type: 'TRANSCRIPT_LANGUAGE_OFF',
@@ -295,8 +438,180 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
         }
       };
       this.viewerService.metaData.transcripts.push('off');
+      this.deactivateWordHighlightTrack();
     }
     this.viewerService.raiseHeartBeatEvent(telemetryObject.type, telemetryObject.extraValues);
+  }
+
+  // Finds a same-language word-level track and arms it as the active source
+  // for the overlay. This never hides native captions by itself - visibility
+  // is entirely decided by updateWordHighlightOverlay/rebuildWordHighlightAt
+  // finding real words to show. That means a wordByWordUrl that's missing,
+  // 404s, is empty/malformed, or simply doesn't cover part of the video needs
+  // no special-case detection: native captions just keep showing whenever the
+  // overlay has nothing, with no timers or video.js-internal load/error
+  // events involved.
+  private activateWordHighlightTrack(languageCode: string) {
+    const textTracks = this.player.textTracks();
+    let wordTrack = null;
+    for (let i = 0; i < textTracks.length; i++) {
+      const track = textTracks[i];
+      if (track.kind === 'metadata' && track.language &&
+        track.language.toLowerCase() === languageCode.toLowerCase()) {
+        wordTrack = track;
+        break;
+      }
+    }
+    if (this.activeWordTrack && this.activeWordTrack !== wordTrack) {
+      this.activeWordTrack.mode = 'disabled';
+    }
+    this.activeWordTrack = wordTrack;
+    this.resetWordHighlightState();
+    if (!wordTrack) {
+      return;
+    }
+    wordTrack.mode = 'hidden';
+    // In case cues are already loaded (e.g. re-enabling a track the user had
+    // on before) and playback is already mid-video, position the overlay
+    // immediately instead of waiting for the next timeupdate tick to sweep
+    // forward from the start of the cue list.
+    this.rebuildWordHighlightAt(this.player.currentTime());
+  }
+
+  private deactivateWordHighlightTrack() {
+    if (this.activeWordTrack) {
+      this.activeWordTrack.mode = 'disabled';
+    }
+    this.activeWordTrack = null;
+    this.resetWordHighlightState();
+    this.renderWordHighlightLine();
+  }
+
+  private resetWordHighlightState() {
+    this.wordHighlightCues = [];
+    this.wordHighlightCueIndex = 0;
+    this.wordHighlightLineWords = [];
+    this.wordHighlightLastCueEnd = 0;
+    this.wordHighlightLineStart = 0;
+    this.setWordHighlightOverlayVisible(false);
+  }
+
+  // video.js does not keep our Angular-rendered <video class="video-js"> tag
+  // as its final DOM root - it builds its own tech/wrapper structure - so an
+  // Angular class binding on that original element does not reliably reach
+  // the same ancestor as the dynamically-created .vjs-text-track-display.
+  // player.addClass/removeClass operate on the tech's actual live root
+  // element, which is what the ::ng-deep hide rule needs to match against.
+  private setWordHighlightOverlayVisible(visible: boolean) {
+    if (this.showWordHighlightOverlay === visible) { return; }
+    this.showWordHighlightOverlay = visible;
+    if (!this.player) { return; }
+    if (visible) {
+      this.player.addClass('word-highlight-active');
+    } else {
+      this.player.removeClass('word-highlight-active');
+    }
+  }
+
+  private ensureWordHighlightCuesLoaded() {
+    if (!this.activeWordTrack || this.wordHighlightCues.length > 0 ||
+      !this.activeWordTrack.cues || this.activeWordTrack.cues.length === 0) {
+      return;
+    }
+    this.wordHighlightCues = Array.from(this.activeWordTrack.cues as any).sort((a: any, b: any) => a.startTime - b.startTime);
+  }
+
+  private updateWordHighlightOverlay(currentTime: number) {
+    if (!this.activeWordTrack) { return; }
+    this.ensureWordHighlightCuesLoaded();
+    let changed = false;
+    while (this.wordHighlightCueIndex < this.wordHighlightCues.length &&
+      this.wordHighlightCues[this.wordHighlightCueIndex].startTime <= currentTime) {
+      const cue = this.wordHighlightCues[this.wordHighlightCueIndex];
+      const gapBroken = cue.startTime - this.wordHighlightLastCueEnd > this.wordHighlightGapThresholdSeconds;
+      const prospectiveLength = this.wordHighlightLineWords.length === 0
+        ? cue.text.length
+        : this.wordHighlightLineWords.join(' ').length + 1 + cue.text.length;
+      const tooManyChars = this.wordHighlightLineWords.length > 0 &&
+        prospectiveLength > this.wordHighlightMaxLineCharacters;
+      if (gapBroken || tooManyChars) {
+        this.wordHighlightLineWords = [];
+      }
+      if (this.wordHighlightLineWords.length === 0) {
+        this.wordHighlightLineStart = cue.startTime;
+      }
+      this.wordHighlightLastCueEnd = cue.endTime;
+      this.wordHighlightLineWords.push(cue.text);
+      this.wordHighlightCueIndex += 1;
+      changed = true;
+    }
+    // No new cue consumed this tick, but the last known word ended long
+    // enough ago (natural sentence gap, end of this VTT's coverage, or a VTT
+    // that never covered this part of the video at all) - clear the stale
+    // line so native captions take back over instead of freezing forever.
+    if (!changed && this.wordHighlightLineWords.length > 0 &&
+      (currentTime - this.wordHighlightLastCueEnd) > this.wordHighlightGapThresholdSeconds) {
+      this.wordHighlightLineWords = [];
+      changed = true;
+    }
+    if (changed) {
+      this.renderWordHighlightLine();
+    }
+    this.setWordHighlightOverlayVisible(this.wordHighlightLineWords.length > 0);
+  }
+
+  private rebuildWordHighlightAt(currentTime: number) {
+    if (!this.activeWordTrack) { return; }
+    this.ensureWordHighlightCuesLoaded();
+    this.wordHighlightCueIndex = 0;
+    while (this.wordHighlightCueIndex < this.wordHighlightCues.length &&
+      this.wordHighlightCues[this.wordHighlightCueIndex].startTime <= currentTime) {
+      this.wordHighlightCueIndex += 1;
+    }
+    this.wordHighlightLineWords = [];
+    this.wordHighlightLastCueEnd = 0;
+    this.wordHighlightLineStart = 0;
+    let start = this.wordHighlightCueIndex - 1;
+    let charCount = start >= 0 ? this.wordHighlightCues[start].text.length : 0;
+    while (start >= 0) {
+      const gapBefore = start > 0
+        ? this.wordHighlightCues[start].startTime - this.wordHighlightCues[start - 1].endTime
+        : Infinity;
+      const prospectiveCharCount = start > 0 ? charCount + 1 + this.wordHighlightCues[start - 1].text.length : Infinity;
+      const tooManyChars = start > 0 && prospectiveCharCount > this.wordHighlightMaxLineCharacters;
+      if (gapBefore > this.wordHighlightGapThresholdSeconds || tooManyChars) { break; }
+      charCount = prospectiveCharCount;
+      start -= 1;
+    }
+    // Only treat the reconstructed line as still "live" if its last word's
+    // cue hasn't already ended beyond the gap threshold relative to
+    // currentTime - keeps seek behavior consistent with normal playback
+    // rather than showing a stale line the moment cues run out.
+    const lastIndex = this.wordHighlightCueIndex - 1;
+    if (lastIndex >= 0 && (currentTime - this.wordHighlightCues[lastIndex].endTime) <= this.wordHighlightGapThresholdSeconds) {
+      this.wordHighlightLineStart = this.wordHighlightCues[Math.max(start, 0)].startTime;
+      for (let i = Math.max(start, 0); i <= lastIndex; i++) {
+        this.wordHighlightLineWords.push(this.wordHighlightCues[i].text);
+        this.wordHighlightLastCueEnd = this.wordHighlightCues[i].endTime;
+      }
+    }
+    this.renderWordHighlightLine();
+    this.setWordHighlightOverlayVisible(this.wordHighlightLineWords.length > 0);
+  }
+
+  private renderWordHighlightLine() {
+    if (!this.wordHighlightLine) { return; }
+    this.wordHighlightLine.nativeElement.innerHTML = this.wordHighlightLineWords
+      .map((word, i) => i === this.wordHighlightLineWords.length - 1
+        ? `<span class="word-highlight-word--current">${this.escapeHtml(word)}</span>`
+        : this.escapeHtml(word))
+      .join(' ');
+  }
+
+  private escapeHtml(text: string): string {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
   }
 
   toggleForwardRewindButton() {
@@ -444,6 +759,9 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   }
 
   ngOnDestroy() {
+    if (this.transcriptsUpdatedSubscription) {
+      this.transcriptsUpdatedSubscription.unsubscribe();
+    }
     if (this.player) {
       this.player.dispose();
     }

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -53,7 +53,6 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   private wordHighlightCueIndex = 0;
   private wordHighlightLineWords: string[] = [];
   private wordHighlightLastCueEnd = 0;
-  private wordHighlightLineStart = 0;
   // Configurable via config.wordHighlight - see ngOnInit.
   private wordHighlightGapThresholdSeconds = 0.3;
   // Independent ceiling on top of the gap-based clearing above - ASR-generated
@@ -492,7 +491,6 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     this.wordHighlightCueIndex = 0;
     this.wordHighlightLineWords = [];
     this.wordHighlightLastCueEnd = 0;
-    this.wordHighlightLineStart = 0;
     this.setWordHighlightOverlayVisible(false);
   }
 
@@ -537,9 +535,6 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
       if (gapBroken || tooManyChars) {
         this.wordHighlightLineWords = [];
       }
-      if (this.wordHighlightLineWords.length === 0) {
-        this.wordHighlightLineStart = cue.startTime;
-      }
       this.wordHighlightLastCueEnd = cue.endTime;
       this.wordHighlightLineWords.push(cue.text);
       this.wordHighlightCueIndex += 1;
@@ -570,7 +565,6 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     }
     this.wordHighlightLineWords = [];
     this.wordHighlightLastCueEnd = 0;
-    this.wordHighlightLineStart = 0;
     let start = this.wordHighlightCueIndex - 1;
     let charCount = start >= 0 ? this.wordHighlightCues[start].text.length : 0;
     while (start >= 0) {
@@ -589,7 +583,6 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
     // rather than showing a stale line the moment cues run out.
     const lastIndex = this.wordHighlightCueIndex - 1;
     if (lastIndex >= 0 && (currentTime - this.wordHighlightCues[lastIndex].endTime) <= this.wordHighlightGapThresholdSeconds) {
-      this.wordHighlightLineStart = this.wordHighlightCues[Math.max(start, 0)].startTime;
       for (let i = Math.max(start, 0); i <= lastIndex; i++) {
         this.wordHighlightLineWords.push(this.wordHighlightCues[i].text);
         this.wordHighlightLastCueEnd = this.wordHighlightCues[i].endTime;

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -594,8 +594,14 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
 
   private renderWordHighlightLine() {
     if (!this.wordHighlightLine) { return; }
+    // Only bold the last word when there are other words on the same line to
+    // contrast it against - for sentence-level VTTs (no real word-level
+    // timing) each line is just a single whole-sentence cue, so marking that
+    // sole item "current" would bold the entire sentence instead of
+    // highlighting anything meaningful.
+    const highlightLast = this.wordHighlightLineWords.length > 1;
     this.wordHighlightLine.nativeElement.innerHTML = this.wordHighlightLineWords
-      .map((word, i) => i === this.wordHighlightLineWords.length - 1
+      .map((word, i) => (highlightLast && i === this.wordHighlightLineWords.length - 1)
         ? `<span class="word-highlight-word--current">${this.escapeHtml(word)}</span>`
         : this.escapeHtml(word))
       .join(' ');

--- a/projects/sunbird-video-player/src/lib/playerInterfaces.ts
+++ b/projects/sunbird-video-player/src/lib/playerInterfaces.ts
@@ -60,6 +60,15 @@ sideMenu?: {
     showReplay?: boolean;
     showExit?: boolean;
 };
+wordHighlight?: {
+    // Below this gap (seconds) between consecutive word cues, the overlay
+    // keeps accumulating them onto the same line. Default 0.3.
+    gapThresholdSeconds?: number;
+    // Max characters per accumulated line (Netflix's per-line cap is ~42).
+    // Guards against word-level VTTs with no pauses at all, where the gap
+    // check alone would never fire. Default 42.
+    maxLineCharacters?: number;
+};
 [propName: string]: any;
 }
 
@@ -74,6 +83,10 @@ export interface Transcript {
     identifier: string;
     artifactUrl: string;
     languageCode: string;
+    wordByWordUrl?: string;
+    // Marks the original/source-language transcript (as opposed to a
+    // translated one) - surfaced as "(Original)" in the captions menu label.
+    sourceLanguage?: boolean;
   }
 export interface Transcripts extends Array <Transcript> {}
 

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.ts
@@ -53,6 +53,10 @@ export class ViewerService {
   public transcripts: Transcripts;
   public playBitStartTime = 0;
   public playBitEndTime = 0;
+  // Set alongside isAvailableLocally in initialize() - reused by
+  // updateTranscripts() so a transcript payload pushed in later (hot-reload)
+  // gets the same offline basePath prefixing as the initial one.
+  private localBasePath: string;
   constructor(private videoPlayerService: SunbirdVideoPlayerService,
               private utilService: UtilService,
               private http: HttpClient,
@@ -89,6 +93,7 @@ export class ViewerService {
     this.endPageSeen = false;
     if (this.isAvailableLocally) {
       const basePath = (metadata.streamingUrl) ? (metadata.streamingUrl) : (metadata.basePath || metadata.baseDir);
+      this.localBasePath = basePath;
       this.streamingUrl = `${basePath}/${metadata.artifactUrl}`;
       this.mimeType = metadata.mimeType;
       // Transcript/caption files ship inside the same offline .ecar bundle as
@@ -96,12 +101,16 @@ export class ViewerService {
       // metadata.artifactUrl above - without this they'd resolve against the
       // page origin instead of the local content basePath and fail to load
       // when playing offline (e.g. downloaded content in the mobile app).
-      this.transcripts = this.transcripts.map((trans) => ({
-        ...trans,
-        artifactUrl: trans.artifactUrl ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,
-        wordByWordUrl: trans.wordByWordUrl ? `${basePath}/${trans.wordByWordUrl}` : trans.wordByWordUrl
-      }));
+      this.transcripts = this.prefixTranscriptUrls(this.transcripts, basePath);
     }
+  }
+
+  private prefixTranscriptUrls(transcripts: Transcripts, basePath: string): Transcripts {
+    return transcripts.map((trans) => ({
+      ...trans,
+      artifactUrl: trans.artifactUrl ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,
+      wordByWordUrl: trans.wordByWordUrl ? `${basePath}/${trans.wordByWordUrl}` : trans.wordByWordUrl
+    }));
   }
   handleTranscriptsData(selectedTranscripts) {
     this.metaData.transcripts = selectedTranscripts;
@@ -125,7 +134,11 @@ export class ViewerService {
   }
 
   updateTranscripts(transcripts: Transcripts) {
-    this.transcripts = transcripts || [];
+    let newTranscripts = transcripts || [];
+    if (this.isAvailableLocally && this.localBasePath) {
+      newTranscripts = this.prefixTranscriptUrls(newTranscripts, this.localBasePath);
+    }
+    this.transcripts = newTranscripts;
     this.transcriptsUpdated.emit(this.transcripts);
   }
   async getPlayerOptions() {

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.ts
@@ -33,6 +33,12 @@ export class ViewerService {
   public visitedLength = 0;
   public uniqueVisitedLength;
   public sidebarMenuEvent = new EventEmitter<any>();
+  // Emits whenever transcripts are updated after initial load (e.g. a
+  // generate-transcript job completing while the player is already mounted).
+  // handleTranscriptsData() itself only recomputes from whatever is already
+  // in `this.transcripts` - updateTranscripts() is the entry point for
+  // pushing in genuinely new data from outside.
+  public transcriptsUpdated = new EventEmitter<Transcripts>();
   public traceId: string;
   public isAvailableLocally = false;
   public interceptionPoints: any;
@@ -85,6 +91,16 @@ export class ViewerService {
       const basePath = (metadata.streamingUrl) ? (metadata.streamingUrl) : (metadata.basePath || metadata.baseDir);
       this.streamingUrl = `${basePath}/${metadata.artifactUrl}`;
       this.mimeType = metadata.mimeType;
+      // Transcript/caption files ship inside the same offline .ecar bundle as
+      // the video and are expected to be relative paths, same as
+      // metadata.artifactUrl above - without this they'd resolve against the
+      // page origin instead of the local content basePath and fail to load
+      // when playing offline (e.g. downloaded content in the mobile app).
+      this.transcripts = this.transcripts.map((trans) => ({
+        ...trans,
+        artifactUrl: trans.artifactUrl ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,
+        wordByWordUrl: trans.wordByWordUrl ? `${basePath}/${trans.wordByWordUrl}` : trans.wordByWordUrl
+      }));
     }
   }
   handleTranscriptsData(selectedTranscripts) {
@@ -106,6 +122,11 @@ export class ViewerService {
       });
     }
     return this.transcripts;
+  }
+
+  updateTranscripts(transcripts: Transcripts) {
+    this.transcripts = transcripts || [];
+    this.transcriptsUpdated.emit(this.transcripts);
   }
   async getPlayerOptions() {
     if (!this.streamingUrl) {

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.ts
@@ -106,6 +106,9 @@ export class ViewerService {
   }
 
   private prefixTranscriptUrls(transcripts: Transcripts, basePath: string): Transcripts {
+    if (!_.isArray(transcripts)) {
+      return transcripts;
+    }
     return transcripts.map((trans) => ({
       ...trans,
       artifactUrl: trans.artifactUrl ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.spec.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.spec.ts
@@ -342,4 +342,40 @@ describe('SunbirdVideoPlayerComponent', () => {
     component.ngOnChanges(changes);
     expect(component.ngOnInit).not.toHaveBeenCalled();
   });
+
+  it('should push new transcripts and keep playerConfig as an object on a subsequent update (object path)', () => {
+    component.isInitialized = true;
+    component.ngOnInit();
+    spyOn(component.viewerService, 'updateTranscripts');
+    const updatedConfig = {
+      ...mockData.playerConfig,
+      metadata: { ...mockData.playerConfig.metadata, transcripts: [{ languageCode: 'en', artifactUrl: 'en.vtt', identifier: 'en-id', language: 'English' }] }
+    };
+    const changes: SimpleChanges = {
+      playerConfig: new SimpleChange(mockData.playerConfig, updatedConfig, false)
+    };
+    component.ngOnChanges(changes);
+    expect(component.viewerService.updateTranscripts).toHaveBeenCalledWith(updatedConfig.metadata.transcripts);
+    expect(typeof component.playerConfig).toBe('object');
+  });
+
+  it('should parse a string playerConfig update and assign it back to this.playerConfig (web-component path)', () => {
+    component.isInitialized = true;
+    component.ngOnInit();
+    spyOn(component.viewerService, 'updateTranscripts');
+    const updatedConfig = {
+      ...mockData.playerConfig,
+      metadata: { ...mockData.playerConfig.metadata, transcripts: [{ languageCode: 'fr', artifactUrl: 'fr.vtt', identifier: 'fr-id', language: 'French' }] }
+    };
+    const changes: SimpleChanges = {
+      playerConfig: new SimpleChange(mockData.playerConfig, JSON.stringify(updatedConfig), false)
+    };
+    component.ngOnChanges(changes);
+    // Prior to this fix, this.playerConfig stayed an unparsed string here,
+    // silently breaking every [config]/[playerConfig] template binding that
+    // depends on it (including this hot-reload path itself).
+    expect(typeof component.playerConfig).toBe('object');
+    expect((component.playerConfig as any).metadata.transcripts).toEqual(updatedConfig.metadata.transcripts);
+    expect(component.viewerService.updateTranscripts).toHaveBeenCalledWith(updatedConfig.metadata.transcripts);
+  });
 });

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
@@ -43,6 +43,13 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
   isFullScreen = false;
   playerAction: IAction;
   public isInitialized = false;
+  // Raw transcripts payload from the last playerConfig applied, kept
+  // separate from viewerService.transcripts (which handlePlayerConfigUpdate
+  // compares against) - viewerService.transcripts gets mutated in place
+  // (offline basePath prefixing, default-language flagging), so comparing
+  // a fresh incoming payload against it would spuriously look "changed" on
+  // every update, even when the host pushed the exact same transcripts.
+  private lastRawTranscripts: any;
 
   constructor(
     public videoPlayerService: SunbirdVideoPlayerService,
@@ -118,6 +125,7 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
 
     /* eslint-disable @typescript-eslint/dot-notation */
     this.nextContent = this.playerConfig?.config?.nextContent;
+    this.lastRawTranscripts = this.playerConfig?.metadata?.transcripts;
     this.traceId = this.playerConfig.config['traceId'];
     this.sideMenuConfig = { ...this.sideMenuConfig, ...this.playerConfig.config.sideMenu };
     this.videoPlayerService.initialize(this.playerConfig);
@@ -138,6 +146,32 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
     if (changes?.playerConfig?.firstChange && this.isInitialized) {
       // Calling for web component explicitly and life cycle works in different order
       this.ngOnInit();
+    } else if (changes?.playerConfig && !changes.playerConfig.firstChange && this.isInitialized) {
+      // A genuine subsequent playerConfig update (e.g. host pushes newly-generated
+      // transcripts while the player is already mounted) - deliberately does NOT
+      // re-run ngOnInit(), which would tear down/recreate state and interrupt
+      // playback. Only transcripts are hot-swappable today; other playerConfig
+      // fields are still effectively fixed after first load.
+      this.handlePlayerConfigUpdate(changes.playerConfig.currentValue);
+    }
+  }
+
+  private handlePlayerConfigUpdate(rawConfig: PlayerConfig | string) {
+    let parsedConfig: PlayerConfig;
+    if (typeof rawConfig === 'string') {
+      try {
+        parsedConfig = JSON.parse(rawConfig);
+      } catch (error) {
+        console.error('Invalid playerConfig update: ', error);
+        return;
+      }
+    } else {
+      parsedConfig = rawConfig;
+    }
+    const newTranscripts = parsedConfig?.metadata?.transcripts;
+    if (newTranscripts && JSON.stringify(newTranscripts) !== JSON.stringify(this.lastRawTranscripts)) {
+      this.lastRawTranscripts = newTranscripts;
+      this.viewerService.updateTranscripts(newTranscripts);
     }
   }
 

--- a/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/sunbird-video-player.component.ts
@@ -3,6 +3,7 @@ import {
   HostListener, ElementRef, ViewChild, AfterViewInit, Renderer2, OnDestroy
 } from '@angular/core';
 import { ErrorService, errorCode, errorMessage, ISideBarEvent } from '@project-sunbird/sunbird-player-sdk-v9';
+import * as _ from 'lodash-es';
 
 import { PlayerConfig } from './playerInterfaces';
 import { IAction } from './playerInterfaces';
@@ -125,7 +126,13 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
 
     /* eslint-disable @typescript-eslint/dot-notation */
     this.nextContent = this.playerConfig?.config?.nextContent;
-    this.lastRawTranscripts = this.playerConfig?.metadata?.transcripts;
+    // Cloned rather than a reference - handleTranscriptsData() mutates
+    // transcript objects in place (adds `default`), and this array is the
+    // same object graph as viewerService.transcripts, so keeping a plain
+    // reference here would make this "raw" snapshot drift right along with
+    // the mutated live data, breaking the change-comparison in
+    // handlePlayerConfigUpdate below.
+    this.lastRawTranscripts = _.cloneDeep(this.playerConfig?.metadata?.transcripts);
     this.traceId = this.playerConfig.config['traceId'];
     this.sideMenuConfig = { ...this.sideMenuConfig, ...this.playerConfig.config.sideMenu };
     this.videoPlayerService.initialize(this.playerConfig);
@@ -168,9 +175,16 @@ export class SunbirdVideoPlayerComponent implements OnInit, AfterViewInit, OnDes
     } else {
       parsedConfig = rawConfig;
     }
+    // Angular sets the raw @Input value before ngOnChanges runs, so in the
+    // web-component path (where playerConfig arrives as a JSON string)
+    // this.playerConfig would otherwise stay a string for the rest of the
+    // component's life - breaking every `[config]`/`[playerConfig]` template
+    // binding and this.config-dependent logic downstream (including
+    // syncTranscriptTracks, which is the whole point of this update path).
+    this.playerConfig = parsedConfig;
     const newTranscripts = parsedConfig?.metadata?.transcripts;
     if (newTranscripts && JSON.stringify(newTranscripts) !== JSON.stringify(this.lastRawTranscripts)) {
-      this.lastRawTranscripts = newTranscripts;
+      this.lastRawTranscripts = _.cloneDeep(newTranscripts);
       this.viewerService.updateTranscripts(newTranscripts);
     }
   }

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-web-component",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {


### PR DESCRIPTION
## Summary

  Adds word-by-word caption highlighting and live transcript updates to the video player.

  ### Features
  - **Word-highlight overlay** — displays a rolling caption line synced to word-level VTT timing, with the
  currently-spoken word bolded. Falls back cleanly to native captions when no word-level track is available.
  - **Hot-reload transcripts** — transcripts can now be added/updated after the player is already mounted (e.g. a
  transcript finishing generation mid-playback), via `addRemoteTextTrack`/`removeRemoteTextTrack` instead of static
  `<track>` elements.
  - **Offline transcript support** — transcript URLs are prefixed with the local `basePath` for offline/local playback, on
  both initial load and hot-reload.
  - **Source language label** — captions menu shows `(Original)` next to the source-language transcript.
  - **Configurable overlay thresholds** — gap and max-line-character limits configurable via `config.wordHighlight`.

  ### Fixes
  - Default caption track now auto-shows correctly when added imperatively (native `default` attribute isn't honored
  post-mount).
  - Avoided a crash from calling `addRemoteTextTrack` before the player's tech is ready.
  - Fixed word-level ASR captions with no gaps rendering as one unbroken wall of text (per-line character cap added).
  - Fixed the current-word highlight style not applying at all (dynamically-injected span was missing Angular's
  view-encapsulation scoping attribute).
  - Bold highlight now only applies when a line has multiple accumulated words — sentence-level VTTs (no real word-level
  timing) no longer incorrectly bold the entire line.

## Removing duplicate VTT fetches

  ### The problem
  Each transcript could end up with **two** text tracks attached — a `captions` track (native
  browser captions) and a `metadata` track (used to drive the word-highlight overlay's timing,
  via `wordByWordUrl`). When `wordByWordUrl` pointed at the same file as the caption's own
  `artifactUrl` (the common case), the browser fetched that identical VTT file twice — once per
  track. With 4 languages, that meant 8 network requests for only 4 distinct files.

  ### The fix
  A separate `metadata` track (and its own fetch) is now only created when `wordByWordUrl`
  genuinely points at a **different** file than `artifactUrl`. When they're the same URL, the
  word-highlight overlay instead reads cues directly off the already-fetched `captions` track —
  no second request.

  ```ts
  private needsDistinctWordTrack(trans: any): boolean {
    return !!trans.wordByWordUrl && trans.wordByWordUrl !== trans.artifactUrl;
  }
```
  - attachTranscriptTracks() / syncTranscriptTracks() only call addRemoteTextTrack() for a
  metadata track when needsDistinctWordTrack() is true.
  - findWordHighlightSource() looks for a dedicated metadata track first; if none exists, it
  falls back to the same-language captions track's own cues.
  - A new activeWordTrackOwned flag tracks whether the currently-active word-highlight source
  is a dedicated track we control (safe to toggle its mode) or the shared captions track (whose
  mode must be left untouched, since native caption rendering depends on it staying showing).

  ## Result

  - Same VTT file is now fetched once per language, not twice.
  - No behavior change to native captions or the word-highlight overlay — only the
  data-sourcing path changed, not what's shown.
  - Backward compatible: if a caller ever does supply a genuinely different wordByWordUrl, the
  original dedicated-metadata-track behavior still applies unchanged.

  ## Why the static `<track>` tag was removed

  Captions can now be added or updated *after* the player has already mounted and started
  playing (e.g. a transcript that finishes generating mid-playback). Supporting that requires
  being able to cleanly add **and remove** caption tracks at runtime.

  video.js's `player.removeRemoteTextTrack()` only works on tracks that were added via
  `player.addRemoteTextTrack()` — it cannot remove a track that was declared statically as an
  HTML `<track>` element inside `<video>`.
  
  To keep track management consistent (one mechanism, not two), *all* transcript tracks —
  including the ones loaded when the video first opens — are now attached imperatively via
  `addRemoteTextTrack()` in `video-player.component.ts`, instead of being rendered as `<track>`
  tags in the template.

  **Impact:** none, functionally — captions still show and switch exactly as before. This is
  purely an internal mechanism change required to support adding/removing caption tracks after
  initial load.

### What is `basePath`?

  `basePath` is the folder location on the device where an offline/downloaded video and its
  related files (captions, transcripts) are stored. It only matters when playing content
  **offline** (`metadata.isAvailableLocally === true`, e.g. content downloaded in the mobile
  app).

  Downloaded files are stored as bare filenames (`video.mp4`, `captions_en.vtt`) with no path
  information. `basePath` is the missing folder path — the player builds the actual loadable
  path as:

  full path = basePath + "/" + filename

  **Example:**
  - `basePath` = `file:///storage/emulated/0/downloads/content123`
  - filename = `captions_en.vtt`
  - → actual path used: `file:///storage/emulated/0/downloads/content123/captions_en.vtt`

  This applies to both the video file (`streamingUrl`) and every transcript file
  (`artifactUrl`/`wordByWordUrl`) for offline playback.

  ### Why `localBasePath` was added

  `basePath` was previously only ever a **local variable** inside `ViewerService.initialize()`
  — computed once, used immediately to prefix the video and transcript paths, and then
  discarded when `initialize()` returned. Nothing else could access it afterward.

  The new `updateTranscripts()` method (used for hot-reload — see below) can run much later,
  well after `initialize()` has already finished. It needs that same `basePath` value to
  correctly prefix any newly-arriving transcript files for offline playback — but since the
  value was never stored anywhere, there was no way for `updateTranscripts()` to know it.

  `localBasePath` fixes this: it's set once (inside `initialize()`, at the exact point
  `basePath` is computed) and persisted on the service so any later call to
  `updateTranscripts()` can reuse the same value. Since `basePath` never changes for the
  lifetime of a given video session, computing it once and reusing it is both correct and
  sufficient — no staleness risk.

  **If `localBasePath` is removed:** offline transcript hot-reload breaks — new transcripts
  arriving after initial load would not get the folder path prefixed, and the player would fail
  to locate those files on the device.

  ### What is "hot-reload" (for transcripts)?

  Hot-reload means **adding or updating captions/transcripts while the video is already
  playing**, without reloading the page or restarting the player.

  **Example:** A video is uploaded with its English transcript ready immediately, while a
  French translation is still being generated in the background. A learner opens the video and
  starts watching with only English captions available. When the French transcript finishes
  generating a minute later, it can be pushed directly into the already-playing player — French
  appears in the captions menu live, with no page refresh and no interruption to playback.

  This is implemented via `ViewerService.updateTranscripts()`, which can be called at any point
  after the video has already loaded to add, update, or remove available captions on the fly —
  as opposed to only being able to set them once, when the player first mounts.

  ### Tests
  - Added unit tests for track attach/sync, word-highlight activation, overlay accumulation, and seek-time reconstruction.
  - Fixed 2 existing tests whose mocks were missing methods now exercised by the new code.