### PR TITLE
chore: bump package versions to 8.3.0 / 2.2.0

### DIFF
--- a/projects/sunbird-video-player/package.json
+++ b/projects/sunbird-video-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-v9",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "peerDependencies": {
     "@angular/common": "19.2.18",
     "@angular/core": "19.2.18",

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-web-component",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Bumps the package versions ahead of publishing, since 8.2.0/2.1.0 are already published to npm:
- `@project-sunbird/sunbird-video-player-v9`: 8.2.0 → 8.3.0
- `@project-sunbird/sunbird-video-player-web-component`: 2.1.0 → 2.2.0

Cherry-picked cleanly from the version-bump commit only (separate from #191, which showed the full history again due to #190 having been squash-merged into `v1.0.3`).