### PR TITLE
Version bump 8.3.0

### DIFF
--- a/projects/sunbird-video-player/package.json
+++ b/projects/sunbird-video-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-v9",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "peerDependencies": {
     "@angular/common": "19.2.18",
     "@angular/core": "19.2.18",

--- a/projects/sunbird-video-player/package.json
+++ b/projects/sunbird-video-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-v9",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "peerDependencies": {
     "@angular/common": "19.2.18",
     "@angular/core": "19.2.18",

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -222,6 +222,18 @@ div[data-marker-key] {
   display: none !important;
 }
 
+// Safari/WebKit renders its OWN native caption UI on <video> via this pseudo-
+// element, independently of - and in addition to - video.js's custom
+// .vjs-text-track-display above. video.js does not suppress it on its own,
+// so both render at once on Safari: the native WebKit captions plus video.js's
+// (or the word-highlight overlay's) rendering of the same cue text - visible
+// as captions appearing twice, stacked, only on Safari (Chrome/Firefox have
+// no equivalent native overlay, so this is Safari-specific).
+:host ::ng-deep .video-js video::-webkit-media-text-track-display,
+:host ::ng-deep .video-js video::-webkit-media-text-track-container {
+  display: none !important;
+}
+
 // Sibling of <video>, positioned against the same ancestor
 // (.sunbird-video-player-container, position:relative) that
 // .player-for-back-ward-controls above already uses to align exactly to the

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.spec.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.spec.ts
@@ -146,6 +146,24 @@ describe('ViewerService', () => {
     expect(service.transcripts[0].wordByWordUrl).toEqual('https://cdn.example.com/captions/en.vtt');
   });
 
+  it('should NOT prefix data: URI transcript urls when isAvailableLocally', () => {
+    const service = TestBed.inject(ViewerService);
+    const dataUri = 'data:text/vtt;base64,V0VCVlRU';
+    service.initialize({
+      context: {},
+      config: {},
+      metadata: {
+        name: 'Test', mimeType: 'video/mp4', identifier: 'do_1',
+        isAvailableLocally: true, basePath: 'file:///content/do_1', artifactUrl: 'video.mp4',
+        transcripts: [
+          { language: 'English', identifier: 'en', languageCode: 'en', artifactUrl: dataUri, wordByWordUrl: dataUri },
+        ],
+      },
+    } as any);
+    expect(service.transcripts[0].artifactUrl).toEqual(dataUri);
+    expect(service.transcripts[0].wordByWordUrl).toEqual(dataUri);
+  });
+
   it('should call getPlayerOptions for streamingUrl ', () => {
     const service = TestBed.inject(ViewerService);
     service.streamingUrl = 'abc.com';

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.spec.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.spec.ts
@@ -112,6 +112,40 @@ describe('ViewerService', () => {
     expect(service.mimeType).toEqual(mockData.playerConfig.metadata.mimeType);
     expect(service.artifactMimeType).toEqual(mockData.playerConfig.metadata.mimeType);
   });
+  it('should prefix relative transcript urls with basePath when isAvailableLocally', () => {
+    const service = TestBed.inject(ViewerService);
+    service.initialize({
+      context: {},
+      config: {},
+      metadata: {
+        name: 'Test', mimeType: 'video/mp4', identifier: 'do_1',
+        isAvailableLocally: true, basePath: 'file:///content/do_1', artifactUrl: 'video.mp4',
+        transcripts: [
+          { language: 'English', identifier: 'en', languageCode: 'en', artifactUrl: 'captions/en.vtt', wordByWordUrl: 'captions/en.vtt' },
+        ],
+      },
+    } as any);
+    expect(service.transcripts[0].artifactUrl).toEqual('file:///content/do_1/captions/en.vtt');
+    expect(service.transcripts[0].wordByWordUrl).toEqual('file:///content/do_1/captions/en.vtt');
+  });
+
+  it('should NOT prefix absolute (remote CDN) transcript urls when isAvailableLocally', () => {
+    const service = TestBed.inject(ViewerService);
+    service.initialize({
+      context: {},
+      config: {},
+      metadata: {
+        name: 'Test', mimeType: 'video/mp4', identifier: 'do_1',
+        isAvailableLocally: true, basePath: 'file:///content/do_1', artifactUrl: 'video.mp4',
+        transcripts: [
+          { language: 'English', identifier: 'en', languageCode: 'en', artifactUrl: 'https://cdn.example.com/captions/en.vtt', wordByWordUrl: 'https://cdn.example.com/captions/en.vtt' },
+        ],
+      },
+    } as any);
+    expect(service.transcripts[0].artifactUrl).toEqual('https://cdn.example.com/captions/en.vtt');
+    expect(service.transcripts[0].wordByWordUrl).toEqual('https://cdn.example.com/captions/en.vtt');
+  });
+
   it('should call getPlayerOptions for streamingUrl ', () => {
     const service = TestBed.inject(ViewerService);
     service.streamingUrl = 'abc.com';

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.ts
@@ -110,9 +110,11 @@ export class ViewerService {
   // need the offline basePath prefix. Absolute URLs (e.g. a remote CDN
   // captions.vtt, as used for AI-generated transcripts) already resolve on
   // their own - prefixing them would concatenate the local basePath onto a
-  // full https:// URL and break caption loading entirely.
+  // full URL and break caption loading entirely. Matches any URI scheme
+  // (RFC 3986), not just "://" ones, so "data:"/"blob:" URLs aren't
+  // mistaken for relative paths and prefixed too.
   private isAbsoluteUrl(url: string): boolean {
-    return /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url) || url.startsWith('//');
+    return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url) || url.startsWith('//');
   }
 
   private prefixTranscriptUrls(transcripts: Transcripts, basePath: string): Transcripts {

--- a/projects/sunbird-video-player/src/lib/services/viewer.service.ts
+++ b/projects/sunbird-video-player/src/lib/services/viewer.service.ts
@@ -96,13 +96,23 @@ export class ViewerService {
       this.localBasePath = basePath;
       this.streamingUrl = `${basePath}/${metadata.artifactUrl}`;
       this.mimeType = metadata.mimeType;
-      // Transcript/caption files ship inside the same offline .ecar bundle as
-      // the video and are expected to be relative paths, same as
-      // metadata.artifactUrl above - without this they'd resolve against the
-      // page origin instead of the local content basePath and fail to load
-      // when playing offline (e.g. downloaded content in the mobile app).
+      // Relative transcript/caption paths (shipped inside the same offline
+      // .ecar bundle as the video, same as metadata.artifactUrl above) need
+      // the local basePath prefix or they'd resolve against the page origin
+      // instead. Absolute URLs (e.g. a remote CDN captions.vtt for
+      // AI-generated transcripts) are left untouched by prefixTranscriptUrls -
+      // the video can be local while captions still load from the network.
       this.transcripts = this.prefixTranscriptUrls(this.transcripts, basePath);
     }
+  }
+
+  // Only relative paths (ECAR-bundled captions, shipped alongside the video)
+  // need the offline basePath prefix. Absolute URLs (e.g. a remote CDN
+  // captions.vtt, as used for AI-generated transcripts) already resolve on
+  // their own - prefixing them would concatenate the local basePath onto a
+  // full https:// URL and break caption loading entirely.
+  private isAbsoluteUrl(url: string): boolean {
+    return /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//.test(url) || url.startsWith('//');
   }
 
   private prefixTranscriptUrls(transcripts: Transcripts, basePath: string): Transcripts {
@@ -111,8 +121,10 @@ export class ViewerService {
     }
     return transcripts.map((trans) => ({
       ...trans,
-      artifactUrl: trans.artifactUrl ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,
-      wordByWordUrl: trans.wordByWordUrl ? `${basePath}/${trans.wordByWordUrl}` : trans.wordByWordUrl
+      artifactUrl: (trans.artifactUrl && !this.isAbsoluteUrl(trans.artifactUrl))
+        ? `${basePath}/${trans.artifactUrl}` : trans.artifactUrl,
+      wordByWordUrl: (trans.wordByWordUrl && !this.isAbsoluteUrl(trans.wordByWordUrl))
+        ? `${basePath}/${trans.wordByWordUrl}` : trans.wordByWordUrl
     }));
   }
   handleTranscriptsData(selectedTranscripts) {

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-web-component",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-web-component",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {


### PR DESCRIPTION
## Summary
  - Fix: transcript captions with an absolute/remote CDN URL (e.g. AI-generated transcripts) were being incorrectly
  prefixed with the local offline `basePath` when a video was played from a downloaded/offline ECAR, producing a broken
  URL and failing to load. `viewer.service.ts` now checks whether a transcript's `artifactUrl`/`wordByWordUrl` is already
  absolute (`isAbsoluteUrl()`) before prefixing — relative ECAR-bundled caption paths are still prefixed as before,
  absolute CDN URLs are left untouched.
  - Fix: captions rendering twice on Safari. Safari/WebKit renders its own native caption UI
  (`::-webkit-media-text-track-display` / `::-webkit-media-text-track-container`) on `<video>` in addition to video.js's
  custom `.vjs-text-track-display`, causing duplicate stacked captions on Safari only. Hid the native WebKit
  pseudo-elements via CSS so video.js's overlay remains the single rendering path.
  - Version bump: `projects/sunbird-video-player` `8.3.0` → `8.4.0`, `web-component` `2.2.0` → `2.3.0`.

  ## Changes
  - `projects/sunbird-video-player/src/lib/services/viewer.service.ts` — added `isAbsoluteUrl()` helper;
  `prefixTranscriptUrls()` now skips prefixing for already-absolute transcript URLs.
  - `projects/sunbird-video-player/src/lib/services/viewer.service.spec.ts` — added tests covering relative (prefixed) and
  absolute/CDN (not prefixed) transcript URLs under `isAvailableLocally`.
  - `projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss` — hide native WebKit
  caption pseudo-elements to fix duplicate captions on Safari.
  - `pr