### PR TITLE
fix: captions menu overlap/readability and capitalize language labels

### DIFF
--- a/projects/sunbird-video-player/package.json
+++ b/projects/sunbird-video-player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-v9",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "peerDependencies": {
     "@angular/common": "19.2.18",
     "@angular/core": "19.2.18",

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss
@@ -50,7 +50,7 @@
 }
 
 .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  background-color: rgba(0, 0, 0, .72);
+  background-color: rgba(0, 0, 0, .95);
 }
 
 .js-focus-visible .vjs-menu li.vjs-selected:hover,
@@ -72,6 +72,11 @@
 .vjs-menu li,
 .vjs-playback-rate .vjs-playback-rate-value {
   font-size: 1.1em;
+}
+
+// video.js creates these elements outside Angular's renderer, so ::ng-deep is required (see note above).
+:host ::ng-deep .vjs-menu li {
+  text-transform: none;
 }
 
 @media screen and (min-width: 768px) {
@@ -249,7 +254,7 @@ div[data-marker-key] {
   display: flex;
   justify-content: center;
   pointer-events: none;
-  z-index: 3;
+  z-index: 2;
 
   &--hidden {
     display: none;

--- a/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
+++ b/projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts
@@ -107,6 +107,7 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
         autoplay: true,
         muted: _.get(this.config, 'muted'),
         playbackRates: [0.5, 1, 1.5, 2],
+        textTrackSettings: false,
         controlBar: {
           children: ['playToggle', 'volumePanel', 'durationDisplay',
             'progressControl', 'remainingTimeDisplay', 'CaptionsButton',
@@ -378,7 +379,8 @@ export class VideoPlayerComponent implements AfterViewInit, OnInit, OnDestroy, O
   private addTranscriptTrack(kind: 'captions' | 'metadata', trans: any) {
     const src = kind === 'captions' ? trans.artifactUrl : trans.wordByWordUrl;
     const sourceSuffix = trans.sourceLanguage ? ' (Original)' : '';
-    const label = kind === 'captions' ? `${trans.language}${sourceSuffix}` : `${trans.language} (word-by-word)`;
+    const language = trans.language ? trans.language.charAt(0).toUpperCase() + trans.language.slice(1) : trans.language;
+    const label = kind === 'captions' ? `${language}${sourceSuffix}` : `${language} (word-by-word)`;
     const isDefault = kind === 'captions' ? !!trans.default : false;
     const trackEl = this.player.addRemoteTextTrack({
       kind,

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-video-player-web-component",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "The web component package for the sunbird video player",
   "main": "assets/video-player/sunbird-video-player.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Same fix as #195 (already merged to `v1.0.3`), applied to `master`:
- Captions/subtitles (CC) menu no longer renders behind the live word-highlight transcript overlay - `.word-highlight-overlay` z-index lowered below the control bar, and menu background opacity increased for contrast.
- Native text-track-settings UI disabled via video.js's own `textTrackSettings: false` option instead of a CSS-only hide.
- Caption language labels (English, French, Arabic, Portuguese, etc.) are now capitalized in the CC menu instead of showing in lowercase.

## Changes
- `projects/sunbird-video-player/src/lib/components/video-player/video-player.component.scss`
- `projects/sunbird-video-player/src/lib/components/video-player/video-player.component.ts`
- `projects/sunbird-video-player/package.json` (8.4.0 -> 8.4.1)
- `web-component/package.json` (2.3.0 -> 2.3.1)

## Testing
Verified visually on a running instance (Sunbird Spark portal, web-component build) that the CC menu renders above the transcript overlay, readable, and language labels are capitalized.